### PR TITLE
Error estimation with variances from observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,29 +47,32 @@ Existing Functionality
 * `model`: function that takes two arguments (x, params)
 * `x`: the independent variable
 * `y`: the dependent variable that constrains `model`
-* `w`: weight applied to the residual; can be a vector (of `length(x)` size) or matrix (inverse covariance)
+* `w`: weight applied to the residual; can be a vector (of `length(x)` size or empty) or matrix (inverse covariance matrix)
 * `p0`: initial guess of the model parameters
 * `kwargs`: tuning parameters for fitting, passed to `levenberg_marquardt`, such as `maxIter` or `show_trace`
 * `fit`: composite type of results (`LsqFitResult`)
 
 
-This performs a fit using a non-linear iteration to minimize the (weighted) residual between the model and the dependent variable data (`y`). The weight (`w`) can be neglected (as per the example) to perform an unweighted fit. An unweighted fit is the numerical equivalent of `w=1` for each point.
+This performs a fit using a non-linear iteration to minimize the (weighted) residual between the model and the dependent variable data (`y`). The weight (`w`) can be neglected (as per the example) to perform an unweighted fit. An unweighted fit is the numerical equivalent of `w=1` for each point  (although unweighted error estimates are handled differently from weighted error estimates even when the weights are uniform).
 
 ----
 
-`sigma = estimate_errors(fit, alpha=0.95)`:
+`sigma = estimate_errors(fit, alpha=0.95; atol, rtol)`:
 
 * `fit`: result of curve_fit (a `LsqFitResult` type)
 * `alpha`: confidence limit to calculate for the errors on parameters
-* `sigma`: typical (symmetric) standard deviation for each parameter
+* `atol`: absolute tolerance for negativity check
+* `rtol`: relative tolerance for negativity check
 
 This returns the error or uncertainty of each parameter fit to the model and already scaled by the associated degrees of freedom.  Please note, this is a LOCAL quantity calculated from the jacobian of the model evaluated at the best fit point and NOT the result of a parameter exploration.
+
+If no weights are provided for the fits, the variance is estimated from the mean squared error of the fits. If weights are provided, the weights are assumed to be the inverse of the variances or of the covariance matrix, and errors are estimated based on these and the jacobian, assuming a linearization of the model around the minimum squared error point.
 
 ----
 
 `covar = estimate_covar(fit)`:
 
 * `fit`: result of curve_fit (a `LsqFitResult` type)
-* `covar`: parameter covariance matrix calculated from the jacobian of the model at the fit point
+* `covar`: parameter covariance matrix calculated from the jacobian of the model at the fit point, using the weights (if specified) as the inverse covariance of observations
 
 This returns the parameter covariance matrix evaluted at the best fit point.

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -92,7 +92,6 @@ function estimate_errors(fit::LsqFitResult, alpha=0.95; rtol::Real=NaN, atol::Re
     #   atol  : absolute tolerance for approximate comparisson to 0.0 in negativity check
     #   rtol  : relative tolerance for approximate comparisson to 0.0 in negativity check
     covar = estimate_covar(fit)        
-    println("size of covar matrix: $(size(covar))")
     
     # then the standard errors are given by the sqrt of the diagonal
     vars = diag(covar)
@@ -104,7 +103,5 @@ function estimate_errors(fit::LsqFitResult, alpha=0.95; rtol::Real=NaN, atol::Re
     
     # scale by quantile of the student-t distribution
     dist = TDist(fit.dof)
-    println("size of std_error: $(size(std_error))")
-    println("size of quantile: $(size(quantile(dist,alpha)))")
     return std_error * quantile(dist, alpha)
 end

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -73,6 +73,19 @@ function estimate_covar(fit::LsqFitResult)
 	Q,R = qr(J)
 	Rinv = inv(R)
 	covar = Rinv*Rinv'*mse
+
+	return covar
+end
+
+function estimate_covar(fit::LsqFitResult, vars::Vector{Float64})
+    # computes covariance matrix of fit parameters
+    r = fit.resid
+    J = fit.jacobian
+
+    Q,R = qr(Diagonal(1./sqrt(vars))*J)
+    Rinv = pinv(R)
+    return Rinv*Rinv'
+    #return inv(Symmetric(J'*Diagonal(1./vars)*J))
 end
 
 function estimate_errors(fit::LsqFitResult, alpha=0.95)
@@ -83,6 +96,24 @@ function estimate_errors(fit::LsqFitResult, alpha=0.95)
 
 	# then the standard errors are given by the sqrt of the diagonal
 	std_error = sqrt(diag(covar))
+
+	# scale by quantile of the student-t distribution
+	dist = TDist(fit.dof)
+	std_error *= quantile(dist, alpha)
+end
+
+function estimate_errors(fit::LsqFitResult, vars::Vector{Float64}, alpha=0.95)
+	# computes (1-alpha) error estimates from
+	#   fit   : a LsqFitResult from a curve_fit()
+	#   alpha : alpha percent confidence interval, (e.g. alpha=0.95 for 95% CI)
+	covar = estimate_covar(fit, vars)
+
+	# then the standard errors are given by the sqrt of the diagonal
+        vars = diag(covar)
+        if minimum(vars)/maximum(vars) < -1e-10
+            error("Covariance matrix is negative")
+        end
+       	std_error = sqrt(abs(vars))
 
 	# scale by quantile of the student-t distribution
 	dist = TDist(fit.dof)

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -17,8 +17,8 @@ let
     @assert norm(errors - [0.017, 0.075]) < 0.01
 
     # some example data
-    yvars = abs(randn(length(xdata)))
-    ydata = model(xdata, [1.0, 2.0]) + 0.005*sqrt(yvars).*randn(length(xdata))
+    yvars = 1e-6*rand(length(xdata))
+    ydata = model(xdata, [1.0, 2.0]) + sqrt(yvars).*randn(length(xdata))
 
     fit = curve_fit(model, xdata, ydata, 1./yvars, [0.5, 0.5])
     println("norm(fit.param - [1.0, 2.0]) < 0.05 ? ", norm(fit.param - [1.0, 2.0]))
@@ -26,7 +26,7 @@ let
     @test fit.converged
 
     # can also get error estimates on the fit parameters
-    errors = estimate_errors(fit,yvars)
-    println("norm(errors - [0.017, 0.075]) < 0.01 ?", norm(errors - [0.017, 0.075]))
-    @assert norm(errors - [0.017, 0.075]) < 0.01
+    errors = estimate_errors(fit)
+    println("norm(errors - [0.017, 0.075]) < 0.1 ?", norm(errors - [0.017, 0.075]))
+    @assert norm(errors - [0.017, 0.075]) < 0.1
 end

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -17,13 +17,15 @@ let
 
     # some example data
     yvars = 1e-4*randn(length(xdata))
-    ydata = model(xdata, [1.0, 2.0]) + sqrt(yvars)*randn(length(xdata))
+    ydata = model(xdata, [1.0, 2.0]) + sqrt(yvars).*randn(length(xdata))
 
     fit = curve_fit(model, xdata, ydata, 1./sqrt(yvars), [0.5, 0.5])
+    println("norm(fit.param - [1.0, 2.0]) < 0.05 ? ", norm(fit.param - [1.0, 2.0]))
     @assert norm(fit.param - [1.0, 2.0]) < 0.05
     @test fit.converged
 
     # can also get error estimates on the fit parameters
     errors = estimate_errors(fit,yvars)
+    println("norm(errors - [0.017, 0.075]) < 0.01 ?", norm(errors - [0.017, 0.075]))
     @assert norm(errors - [0.017, 0.075]) < 0.01
 end

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -14,4 +14,16 @@ let
     # can also get error estimates on the fit parameters
     errors = estimate_errors(fit)
     @assert norm(errors - [0.017, 0.075]) < 0.01
+
+    # some example data
+    yvars = 1e-4*randn(length(xdata))
+    ydata = model(xdata, [1.0, 2.0]) + sqrt(yvars)*randn(length(xdata))
+
+    fit = curve_fit(model, xdata, ydata, 1./sqrt(yvars), [0.5, 0.5])
+    @assert norm(fit.param - [1.0, 2.0]) < 0.05
+    @test fit.converged
+
+    # can also get error estimates on the fit parameters
+    errors = estimate_errors(fit,yvars)
+    @assert norm(errors - [0.017, 0.075]) < 0.01
 end

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -17,10 +17,10 @@ let
     @assert norm(errors - [0.017, 0.075]) < 0.01
 
     # some example data
-    yvars = 1e-4*randn(length(xdata))
-    ydata = model(xdata, [1.0, 2.0]) + sqrt(yvars).*randn(length(xdata))
+    yvars = abs(randn(length(xdata)))
+    ydata = model(xdata, [1.0, 2.0]) + 0.005*sqrt(yvars).*randn(length(xdata))
 
-    fit = curve_fit(model, xdata, ydata, 1./sqrt(yvars), [0.5, 0.5])
+    fit = curve_fit(model, xdata, ydata, 1./yvars, [0.5, 0.5])
     println("norm(fit.param - [1.0, 2.0]) < 0.05 ? ", norm(fit.param - [1.0, 2.0]))
     @assert norm(fit.param - [1.0, 2.0]) < 0.05
     @test fit.converged


### PR DESCRIPTION
Could you take a peek, @blakejohnson ?  

I am not happy to have the `pinv` for computing the covariance of the estimates, but it seemed necessary.  I tried inverses of symmetric and Hermitian matrices, but they still failed occasionally on some test data I have (fits to Ramsey interferometry data). Any suggestions would be welcome.

The computation of the covariance matrix in terms of the variance of the observations is based on a similar calculation for weighted linear least squares (in essence, we assume linearization around the minimum found).