### PR TITLE
Fix incorrect markdown format

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Existing Functionality
 `fit = curve_fit(model, [jacobian], x, y, [w,] p0; kwargs...)`:
 
 * `model`: function that takes two arguments (x, params)
-# `jacobian`: (optional) function that returns the Jacobian matrix of `model`
+* `jacobian`: (optional) function that returns the Jacobian matrix of `model`
 * `x`: the independent variable
 * `y`: the dependent variable that constrains `model`
 * `w`: (optional) weight applied to the residual; can be a vector (of `length(x)` size or empty) or matrix (inverse covariance matrix)


### PR DESCRIPTION
Also make README.md non-executable again.
Both of these were introduced in 9f78143eec53deacf62f66f43d0b3259cedddd2a