### PR TITLE
Decompose estimate_errors() and redefine alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ fit = curve_fit(model, xdata, ydata, p0)
 #	fit.jacobian: estimated Jacobian at solution
 
 # We can estimate errors on the fit parameters,
-# to get 95% confidence error bars:
-errors = estimate_errors(fit, 0.95)
+# to get standard errors and margin of errors at 5% significance level:
+sigma = standard_errors(fit)
+margin_of_errors = margin_errors(fit, 0.05)
 
 # The finite difference method is used above to approximate the Jacobian.
 # Alternatively, a function which calculates it exactly can be supplied instead.
@@ -69,16 +70,34 @@ This performs a fit using a non-linear iteration to minimize the (weighted) resi
 
 ----
 
-`sigma = estimate_errors(fit, alpha=0.95; atol, rtol)`:
+`sigma = standard_errors(fit; atol, rtol)`:
 
 * `fit`: result of curve_fit (a `LsqFitResult` type)
-* `alpha`: confidence limit to calculate for the errors on parameters
 * `atol`: absolute tolerance for negativity check
 * `rtol`: relative tolerance for negativity check
 
 This returns the error or uncertainty of each parameter fit to the model and already scaled by the associated degrees of freedom.  Please note, this is a LOCAL quantity calculated from the jacobian of the model evaluated at the best fit point and NOT the result of a parameter exploration.
 
 If no weights are provided for the fits, the variance is estimated from the mean squared error of the fits. If weights are provided, the weights are assumed to be the inverse of the variances or of the covariance matrix, and errors are estimated based on these and the jacobian, assuming a linearization of the model around the minimum squared error point.
+
+
+`margin_of_errors = margin_errors(fit, alpha=0.05; atol, rtol)`:
+
+* `fit`: result of curve_fit (a `LsqFitResult` type)
+* `alpha`: significance level
+* `atol`: absolute tolerance for negativity check
+* `rtol`: relative tolerance for negativity check
+
+This returns the product of standard errors and critical values at `alpha` significance level.
+
+`estimate_errors(fit, alpha=0.05; atol, rtol)`:
+
+* `fit`: result of curve_fit (a `LsqFitResult` type)
+* `alpha`: significance level
+* `atol`: absolute tolerance for negativity check
+* `rtol`: relative tolerance for negativity check
+
+This prints out estimated standard errors, margin of errors and confidence intervals at `alpha` significance level.
 
 ----
 

--- a/src/LsqFit.jl
+++ b/src/LsqFit.jl
@@ -2,6 +2,8 @@ module LsqFit
 
     export curve_fit,
            estimate_errors,
+           standard_errors,
+           margin_errors,
            estimate_covar
 
     using Calculus

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -14,7 +14,7 @@ let
     @test fit.converged
 
     # can also get error estimates on the fit parameters
-    errors = estimate_errors(fit)
+    errors = margin_errors(fit, 0.1)
     @assert norm(errors - [0.017, 0.075]) < 0.01
 
     # if your model is differentiable, it can be faster and/or more accurate
@@ -39,7 +39,7 @@ let
     @test fit.converged
 
     # can also get error estimates on the fit parameters
-    errors = estimate_errors(fit)
+    errors = margin_errors(fit, 0.1)
     println("norm(errors - [0.017, 0.075]) < 0.1 ?", norm(errors - [0.017, 0.075]))
     @assert norm(errors - [0.017, 0.075]) < 0.1
 


### PR DESCRIPTION
Fix issue https://github.com/JuliaNLSolvers/LsqFit.jl/issues/64.

`estimate_errors()` is decomposed into `standard_errors()`, `margin_errors()` and `estimate_errors()`. `standard_errors()` and `margin_errors()` will return standard errors and margin of errors, while `estimate_errors()` will print out standard errors, margin of errors and confidence intervals.  What the present `estimate_errors()` does is equal to `margin_errors()`.

The `alpha` parameter should be defined as significance level to reduce ambiguity and therefore use `quantile(dist, 1 - alpha/2)` to find (two-sided) critical values. Present version of `estimate_errors(fit, alpha=0.95)` is actually finding 90% confidence interval if I'm understanding the code correctly.