### PR TITLE
Change weight parameter to standard deviation and covariance parameter

### DIFF
--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -41,9 +41,7 @@ end
 """
     curve_fit(model, [jacobian], x, y, [sigma,] p0; kwargs...)
 
-Fit data to a non-linear `model` by minimizing the (weighted) residual between the model and the dependent variable data (`y`). `p0` is an initial model parameter guess.
-
-The weight (`w`) can be neglected to perform an unweighted fit. An unweighted fit is the numerical equivalent of `w=1` for each point, though unweighted error estimates are handled differently from weighted error estimates even when the weights are uniform.
+Fit data to a non-linear `model` by minimizing the (transformed) residual between the model and the dependent variable data (`y`). `p0` is an initial model parameter guess.
 
 The return object is a composite type (`LsqFitResult`), with some interesting values:
 
@@ -57,8 +55,8 @@ The return object is a composite type (`LsqFitResult`), with some interesting va
 * `jacobian`: (optional) function that returns the Jacobian matrix of `model`
 * `x`: the independent variable
 * `y`: the dependent variable that constrains `model`
-* `sigma::Vector`: (optional) the standard deviations of errors.
-* `sigma::Matrix`: (optional) the covariance matrix of errors.
+* `sigma::Vector`: (optional) the standard deviations of errors to perform Weighted Least Squares.
+* `sigma::Matrix`: (optional) the covariance matrix of errors to perform General Least Squares.
 * `p0`: initial guess of the model parameters
 * `kwargs`: tuning parameters for fitting, passed to `levenberg_marquardt`, such as `maxIter` or `show_trace`
 

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -33,7 +33,7 @@ let
     yvars = 1e-6*rand(length(xdata))
     ydata = model(xdata, [1.0, 2.0]) + @compat sqrt.(yvars) .* randn(length(xdata))
 
-    fit = curve_fit(model, xdata, ydata, 1 ./ yvars, [0.5, 0.5])
+    fit = curve_fit(model, xdata, ydata, yvars, [0.5, 0.5])
     println("norm(fit.param - [1.0, 2.0]) < 0.05 ? ", norm(fit.param - [1.0, 2.0]))
     @assert norm(fit.param - [1.0, 2.0]) < 0.05
     @test fit.converged
@@ -44,7 +44,7 @@ let
     @assert norm(errors - [0.017, 0.075]) < 0.1
 
     # test with user-supplied jacobian and weights
-    fit = curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, [0.5, 0.5])
+    fit = curve_fit(model, jacobian_model, xdata, ydata, yvars, [0.5, 0.5])
     println("norm(fit.param - [1.0, 2.0]) < 0.05 ? ", norm(fit.param - [1.0, 2.0]))
     @assert norm(fit.param - [1.0, 2.0]) < 0.05
     @test fit.converged

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -30,10 +30,10 @@ let
     @test jacobian_fit.converged
 
     # some example data
-    yvars = 1e-6*rand(length(xdata))
-    ydata = model(xdata, [1.0, 2.0]) + @compat sqrt.(yvars) .* randn(length(xdata))
+    ystdd = 1e-6*rand(length(xdata))
+    ydata = model(xdata, [1.0, 2.0]) + ystdd .* randn(length(xdata))
 
-    fit = curve_fit(model, xdata, ydata, yvars, [0.5, 0.5])
+    fit = curve_fit(model, xdata, ydata, ystdd, [0.5, 0.5])
     println("norm(fit.param - [1.0, 2.0]) < 0.05 ? ", norm(fit.param - [1.0, 2.0]))
     @assert norm(fit.param - [1.0, 2.0]) < 0.05
     @test fit.converged
@@ -43,8 +43,8 @@ let
     println("norm(errors - [0.017, 0.075]) < 0.1 ?", norm(errors - [0.017, 0.075]))
     @assert norm(errors - [0.017, 0.075]) < 0.1
 
-    # test with user-supplied jacobian and weights
-    fit = curve_fit(model, jacobian_model, xdata, ydata, yvars, [0.5, 0.5])
+    # test with user-supplied jacobian and covariance matrix
+    fit = curve_fit(model, jacobian_model, xdata, ydata, diagm(ystdd.^2), [0.5, 0.5])
     println("norm(fit.param - [1.0, 2.0]) < 0.05 ? ", norm(fit.param - [1.0, 2.0]))
     @assert norm(fit.param - [1.0, 2.0]) < 0.05
     @test fit.converged


### PR DESCRIPTION
Another possible fix for #69 but involves more changes. We should change the weight parameter as error standard deviation vector and covariance matrix parameter. 

Some reasons for proposing this modification:

1. Improve performance. As explained in #69, passing standard deviation (σ) to residual function will reduce computation needed if the standard deviation is estimated using `abs.(fit.resid)`. An example notebook is [here](https://gist.github.com/iewaij/2433d550f2952dd4fc311ba8bcb0b2dc).
2. Reduce ambiguity. This will explicitly tell user to pass error variances/covariances. Passing a vector of ones will mean the variances of error are ones, rather than performing an unweighted version of least squares, which causes #70. 
3. Still reduce ambiguity. If the weight is passed as the inverse of error covariance matrix (Σ), it is actually performing GLS rather than WLS, unless the error covariance matrix (Σ) is a diagonal matrix.

Downsides:

1. Unlike OLS, non-linear regression is biased. Therefore, the weight does matter for parameter estimation. The estimated parameters will be different if different weights are passed. If the user wants to perform a least squares using certain weights and doesn't care about variance inference, this change will be annoying.