### PR TITLE
Add and use mse and export rss

### DIFF
--- a/src/LsqFit.jl
+++ b/src/LsqFit.jl
@@ -6,7 +6,7 @@ module LsqFit
            confidence_interval,
            estimate_covar,
            # StatsBase reexports
-           dof, coef, nobs,
+           dof, coef, nobs, mse, rss,
            stderr, weights, residuals
 
     using Distributions


### PR DESCRIPTION
All the non-optimization related changes from #79 are now included in master (after this PR is merged). I'm not going to include the R2 and adjR2 squares for reasons summed up by Douglas Bates in the quote 

```
    There is a good reason that an nls model fit in R does not provide
    r-squared – r-squared doesn’t make sense for a general nls model.

    One way of thinking of r-squared is as a comparison of the residual sum of
    squares for the fitted model to the residual sum of squares for a trivial
    model that consists of a constant only. You cannot guarantee that this is a
    comparison of nested models when dealing with an nls model. If the models
    aren’t nested this comparison is not terribly meaningful.

    So the answer is that you probably don’t want to do this in the first place.
```

People who really want to can still calculate R2, it's not a hard function to write. I'm pretty sure @blakejohnson shares my POV here. ( a lengthy response can be found here while online https://stat.ethz.ch/pipermail/r-help/2000-August/007778.html )