### PR TITLE
Add support for inplace jacobian and model for unidimensional input

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ The default is to calculate the Jacobian using a central finite differences sche
 fit = curve_fit(model, xdata, ydata, p0; autodiff=:forwarddiff)
 ```
 
-Inplace model and/or jacobian 
+Inplace model and jacobian 
 -------------------------
-It is possible to use an inplace model and/or jacobian for univariate regression. It might be pertinent to use this feature when `curve_fit` is slow, or consumes a lot of memory
+It is possible to either use an inplace model, or an inplace model *and* an inplace jacobian for univariate regression. It might be pertinent to use this feature when `curve_fit` is slow, or consumes a lot of memory
 ```
 model_inplace(F, x, p) = (@. F = p[1] * exp(-x * p[2]))
 
@@ -91,7 +91,7 @@ function jacobian_inplace(J::Array{Float64,2},x,p)
         @. J[:,1] = exp(-x*p[2])     
         @. @views J[:,2] = -x*p[1]*J[:,1] 
     end
-fit = curve_fit(model_inplace, jacobian_inplace, xdata, ydata, p0; inplacejac = true, inplacef = true)
+fit = curve_fit(model_inplace, jacobian_inplace, xdata, ydata, p0; inplace = true)
 ```
 
 Existing Functionality

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ fit = curve_fit(model, xdata, ydata, p0; autodiff=:forwarddiff)
 
 Inplace model and jacobian 
 -------------------------
-It is possible to either use an inplace model, or an inplace model *and* an inplace jacobian for univariate regression. It might be pertinent to use this feature when `curve_fit` is slow, or consumes a lot of memory
+It is possible to either use an inplace model, or an inplace model *and* an inplace jacobian. It might be pertinent to use this feature when `curve_fit` is slow, or consumes a lot of memory
 ```
 model_inplace(F, x, p) = (@. F = p[1] * exp(-x * p[2]))
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ The default is to calculate the Jacobian using a central finite differences sche
 fit = curve_fit(model, xdata, ydata, p0; autodiff=:forwarddiff)
 ```
 
+Inplace jacobian
+-------------------------
+It is possible to use an inplace jacobian for univariate regression. It might be pertinent to use this feature when `curve_fit` is slow, or consume a lot of memory
+```
+function jacobian_model(J,x,p)
+    J[:,1] = exp.(-x.*p[2])    #dmodel/dp[1]
+    J[:,2] = -x.*p[1].*J[:,1]  #dmodel/dp[2]
+end
+fit = curve_fit(model, jacobian, xdata, ydata, p0; inplacejac = true)
+```
+
 Existing Functionality
 ----------------------
 

--- a/src/LsqFit.jl
+++ b/src/LsqFit.jl
@@ -12,7 +12,7 @@ module LsqFit
     using Distributions
     using OptimBase
     using LinearAlgebra
-    import NLSolversBase: value, jacobian, f!_from_f
+    import NLSolversBase: value, jacobian
     import StatsBase
     import StatsBase: coef, dof, nobs, rss, stderror, weights, residuals
 

--- a/src/LsqFit.jl
+++ b/src/LsqFit.jl
@@ -12,7 +12,7 @@ module LsqFit
     using Distributions
     using OptimBase
     using LinearAlgebra
-    import NLSolversBase: value, jacobian
+    import NLSolversBase: value, jacobian, f!_from_f
     import StatsBase
     import StatsBase: coef, dof, nobs, rss, stderror, weights, residuals
 

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -29,7 +29,7 @@ function lmfit(f!, g!, p0::AbstractArray, wt::AbstractArray, r::AbstractArray; k
 end
 
 #for inplace f only
-function lmfit(f!, p0, wt::AbstractArray, r::AbstractArray; autodiff = :finite, kwargs...)
+function lmfit(f!, p0::AbstractArray, wt::AbstractArray, r::AbstractArray; autodiff = :finite, kwargs...)
     autodiff = autodiff == :forwarddiff ? :forward : autodiff
     R = OnceDifferentiable(f!, p0, similar(r); inplace = true, autodiff = autodiff)
     lmfit(R, p0, wt; kwargs...)

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -15,7 +15,7 @@ StatsBase.weights(lfr::LsqFitResult) = lfr.wt
 StatsBase.residuals(lfr::LsqFitResult) = lfr.resid
 mse(lfr::LsqFitResult) = rss(lfr)/dof(lfr)
 
-f!_from_f(f, F::AbstractArray) = f!_from_f(f, F::AbstractArray, inplace=false)
+f!_from_f(f, F::AbstractArray) = f!_from_f(f, F::AbstractArray, false)
 
 # provide a method for those who have their own Jacobian function
 function lmfit(f, g, p0, wt; autodiff = :finite, inplacejac = false, kwargs...)

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -16,7 +16,7 @@ StatsBase.residuals(lfr::LsqFitResult) = lfr.resid
 mse(lfr::LsqFitResult) = rss(lfr)/dof(lfr)
 
 # provide a method for those who have their own (non inplace) Jacobian function
-function lmfit(f, g::Function, p0, wt; kwargs...)
+function lmfit(f, g, p0, wt; kwargs...)
     r = f(p0)
     R = OnceDifferentiable(f, g, p0, similar(r); inplace = false)
     lmfit(R, p0, wt; kwargs...)
@@ -94,7 +94,7 @@ fit = curve_fit(model, xdata, ydata, p0)
 """
 function curve_fit end
 
-function curve_fit(model::Function, xpts::AbstractArray, ydata::AbstractArray, p0; inplace = false, kwargs...)
+function curve_fit(model, xpts::AbstractArray, ydata::AbstractArray, p0; inplace = false, kwargs...)
     # construct the cost function
     T = eltype(ydata)
 
@@ -107,7 +107,7 @@ function curve_fit(model::Function, xpts::AbstractArray, ydata::AbstractArray, p
     end
 end
 
-function curve_fit(model::Function, jacobian_model::Function,
+function curve_fit(model, jacobian_model,
             xpts::AbstractArray, ydata::AbstractArray, p0; inplace = false, kwargs...)
 
     T = eltype(ydata)
@@ -123,7 +123,7 @@ function curve_fit(model::Function, jacobian_model::Function,
     end
 end
 
-function curve_fit(model::Function, xpts::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0; inplace = false, kwargs...) where T
+function curve_fit(model, xpts::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0; inplace = false, kwargs...) where T
     # construct a weighted cost function, with a vector weight for each ydata
     # for example, this might be wt = 1/sigma where sigma is some error term
     u = sqrt.(wt) # to be consistant with the matrix form
@@ -137,7 +137,7 @@ function curve_fit(model::Function, xpts::AbstractArray, ydata::AbstractArray, w
     end
 end
 
-function curve_fit(model::Function, jacobian_model::Function,
+function curve_fit(model, jacobian_model,
             xpts::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0; inplace = false, kwargs...) where T
 
     u = sqrt.(wt) # to be consistant with the matrix form
@@ -153,7 +153,7 @@ function curve_fit(model::Function, jacobian_model::Function,
     end
 end
 
-function curve_fit(model::Function, xpts::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T,2}, p0; kwargs...) where T
+function curve_fit(model, xpts::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T,2}, p0; kwargs...) where T
     # as before, construct a weighted cost function with where this
     # method uses a matrix weight.
     # for example: an inverse_covariance matrix
@@ -167,7 +167,7 @@ function curve_fit(model::Function, xpts::AbstractArray, ydata::AbstractArray, w
     lmfit(f,p0,wt; kwargs...)
 end
 
-function curve_fit(model::Function, jacobian_model::Function,
+function curve_fit(model, jacobian_model,
             xpts::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T,2}, p0; kwargs...) where T
     u = cholesky(wt).U
 

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -15,8 +15,6 @@ StatsBase.weights(lfr::LsqFitResult) = lfr.wt
 StatsBase.residuals(lfr::LsqFitResult) = lfr.resid
 mse(lfr::LsqFitResult) = rss(lfr)/dof(lfr)
 
-f!_from_f(f, F::AbstractArray) = f!_from_f(f, F::AbstractArray, false)
-
 # provide a method for those who have their own (non inplace) Jacobian function
 function lmfit(f, g::Function, p0, wt; kwargs...)
     r = f(p0)

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -121,7 +121,7 @@ function curve_fit(model::Function, jacobian_model::Function,
         lmfit(f!, g!, p0, T[], similar(ydata); kwargs...)
     elseif inplacef
         f! = (F,p) -> (model(F,xpts,p); @. F = F - ydata) 
-        g! = (G,p) -> (f!_from_f(jacobian_model(xpts, p),ydata))(G,p)
+        g! = (G,p) -> (f!_from_f((p) -> jacobian_model(xpts, p),ydata))(G,p)
         lmfit(f!, g!, p0, T[], similar(ydata); kwargs...)
     elseif inplacejac
         f = (p) -> model(xpts, p) - ydata
@@ -159,7 +159,7 @@ function curve_fit(model::Function, jacobian_model::Function,
         lmfit(f!, g!, p0, wt, ydata; kwargs...)
     elseif inplacef
         f! = (F,p) -> (model(F,xpts,p); @. F = u*(F - ydata))
-        g! = (G,p) -> (f!_from_f(u .* jacobian_model(xpts, p),ydata))(G,p)
+        g! = (G,p) -> (f!_from_f( (p) -> u .* jacobian_model(xpts, p),ydata))(G,p)
         lmfit(f!, g!, p0, wt, ydata; kwargs...)
     elseif inplacejac
         f = (p) -> u .* ( model(xpts, p) - ydata )

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -44,7 +44,7 @@ function lmfit(f, p0, wt; autodiff = :finite, kwargs...)
     lmfit(R, p0, wt; kwargs...)
 end
 
-function lmfit(R::OnceDifferentiable, p0, wt; autodiff = :finite, inplacejac = false, kwargs...)
+function lmfit(R::OnceDifferentiable, p0, wt; autodiff = :finite, kwargs...)
     results = levenberg_marquardt(R, p0; kwargs...)
     p = minimizer(results)
     return LsqFitResult(p, value!(R, p), jacobian!(R, p), converged(results), wt)
@@ -195,12 +195,6 @@ function confidence_interval(fit::LsqFitResult, alpha=0.05; rtol::Real=NaN, atol
     std_errors = stderror(fit; rtol=rtol, atol=atol)
     margin_of_errors = margin_error(fit, alpha; rtol=rtol, atol=atol)
     confidence_intervals = collect(zip(coef(fit) - margin_of_errors, coef(fit) + margin_of_errors))
-end
-
-function f!_from_f(f, F::AbstractArray) #from NLSolversBase
-    return function ff!(F, x)
-            copyto!(F, f(x))
-    end
 end
 
 @deprecate standard_errors(args...; kwargs...) stderror(args...; kwargs...)

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -18,10 +18,23 @@ mse(lfr::LsqFitResult) = rss(lfr)/dof(lfr)
 f!_from_f(f, F::AbstractArray) = f!_from_f(f, F::AbstractArray, false)
 
 # provide a method for those who have their own Jacobian function
-function lmfit(f, g, p0, wt; autodiff = :finite, inplacejac = false, kwargs...)
+function lmfit(f, g::Function, p0, wt; inplacejac = false, kwargs...)
     r = f(p0)
     finalf = inplacejac ? f!_from_f(f,r) : f #we need to transform f since the `inplace` requires both f and g to be inplace
     R = OnceDifferentiable(finalf, g, p0, similar(r); inplace = inplacejac)
+    lmfit(R, p0, wt; kwargs...)
+end
+
+#for inplace f and inplace g
+function lmfit(f!, g!, p0, wt, r; kwargs...)
+    R = OnceDifferentiable(f!, g!, p0, similar(r); inplace = true)
+    lmfit(R, p0, wt; kwargs...)
+end
+
+#for inplace f only
+function lmfit(f!, p0, wt, r; autodiff = :finite, kwargs...)
+    autodiff = autodiff == :forwarddiff ? :forward : autodiff
+    R = OnceDifferentiable(f!, p0, similar(r); inplace = true, autodiff = autodiff)
     lmfit(R, p0, wt; kwargs...)
 end
 
@@ -84,39 +97,81 @@ fit = curve_fit(model, xdata, ydata, p0)
 """
 function curve_fit end
 
-function curve_fit(model::Function, xpts::AbstractArray, ydata::AbstractArray, p0; kwargs...)
+function curve_fit(model::Function, xpts::AbstractArray, ydata::AbstractArray, p0; inplacef = false, kwargs...)
     # construct the cost function
-    f(p) = model(xpts, p) - ydata
     T = eltype(ydata)
-    lmfit(f,p0,T[]; kwargs...)
+
+    if inplacef
+        f! = (F,p)  -> (model(F,xpts,p); @. F = F - ydata)
+        lmfit(f!, p0, T[], ydata; kwargs...)
+    else
+        f = (p) -> model(xpts, p) - ydata
+        lmfit(f,p0,T[]; kwargs...)
+    end
 end
 
 function curve_fit(model::Function, jacobian_model::Function,
-            xpts::AbstractArray, ydata::AbstractArray, p0; inplacejac = false, kwargs...)
-    f(p) = model(xpts, p) - ydata
-    g = inplacejac ? (G,p) -> jacobian_model(G, xpts, p) : p -> jacobian_model(xpts, p)
+            xpts::AbstractArray, ydata::AbstractArray, p0; inplacef = false, inplacejac = false, kwargs...)
+
     T = eltype(ydata)
-    lmfit(f, g, p0, T[]; inplacejac = inplacejac, kwargs...)
+
+    if (inplacejac && inplacef)
+        f! = (F,p) -> (model(F,xpts,p); @. F = F - ydata)
+        g! = (G,p)  -> jacobian_model(G, xpts, p)
+        lmfit(f!, g!, p0, T[], similar(ydata); kwargs...)
+    elseif inplacef
+        f! = (F,p) -> (model(F,xpts,p); @. F = F - ydata) 
+        g! = (G,p) -> (f!_from_f(jacobian_model(xpts, p),ydata))(G,p)
+        lmfit(f!, g!, p0, T[], similar(ydata); kwargs...)
+    elseif inplacejac
+        f = (p) -> model(xpts, p) - ydata
+        g! = (G,p) -> jacobian_model(G, xpts, p)
+        lmfit(f, g!, p0, T[]; inplacejac = true, kwargs...)
+    else 
+        f = (p) -> model(xpts, p) - ydata
+        g = (p) -> jacobian_model(xpts, p)
+        lmfit(f, g, p0, T[]; kwargs...)
+    end
 end
 
-function curve_fit(model::Function, xpts::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0; kwargs...) where T
+function curve_fit(model::Function, xpts::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0; inplacef = false, kwargs...) where T
     # construct a weighted cost function, with a vector weight for each ydata
     # for example, this might be wt = 1/sigma where sigma is some error term
     u = sqrt.(wt) # to be consistant with the matrix form
-
-    f(p) = u .* ( model(xpts, p) - ydata )
-    lmfit(f,p0,wt; kwargs...)
+    
+    if inplacef
+        f! = (F,p) -> (model(F,xpts,p); @. F = u*(F - ydata))
+        lmfit(f!, p0, wt, ydata; kwargs...)
+    else
+        f = (p)  -> u .* ( model(xpts, p) - ydata )
+        lmfit(f,p0,wt; kwargs...)
+    end
 end
 
 function curve_fit(model::Function, jacobian_model::Function,
-            xpts::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0; inplacejac = false, kwargs...) where T
+            xpts::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0; inplacef = false, inplacejac = false, kwargs...) where T
 
     u = sqrt.(wt) # to be consistant with the matrix form
 
-    f(p) = u .* ( model(xpts, p) - ydata )
-    g = inplacejac ? (G,p) -> (jacobian_model(G, xpts, p); @. G = u*G ) : p -> u .* (jacobian_model(xpts, p))
-    #g(p) = u .* ( jacobian_model(xpts, p) )
-    lmfit(f, g, p0, wt; inplacejac = inplacejac, kwargs...)
+    if (inplacef && inplacejac)
+        f! = (F,p) -> (model(F,xpts,p); @. F = u*(F - ydata))
+        g! = (G,p) -> (jacobian_model(G, xpts, p); @. G = u*G )
+        lmfit(f!, g!, p0, wt, ydata; kwargs...)
+    elseif inplacef
+        f! = (F,p) -> (model(F,xpts,p); @. F = u*(F - ydata))
+        g! = (G,p) -> (f!_from_f(u .* jacobian_model(xpts, p),ydata))(G,p)
+        lmfit(f!, g!, p0, wt, ydata; kwargs...)
+    elseif inplacejac
+        f = (p) -> u .* ( model(xpts, p) - ydata )
+        g! = (G,p) -> (jacobian_model(G, xpts, p); @. G = u*G )
+        lmfit(f, g!, p0, wt; inplacejac = true, kwargs...)
+    else 
+        f = (p) -> u .* ( model(xpts, p) - ydata )
+        g = (p) -> u .* ( jacobian_model(xpts, p) )
+        lmfit(f, g, p0, wt; kwargs...)
+    end
+
+
 end
 
 function curve_fit(model::Function, xpts::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T,2}, p0; kwargs...) where T

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -15,6 +15,8 @@ StatsBase.weights(lfr::LsqFitResult) = lfr.wt
 StatsBase.residuals(lfr::LsqFitResult) = lfr.resid
 mse(lfr::LsqFitResult) = rss(lfr)/dof(lfr)
 
+f!_from_f(f, F::AbstractArray) = f!_from_f(f, F::AbstractArray, inplace=false)
+
 # provide a method for those who have their own Jacobian function
 function lmfit(f, g, p0, wt; autodiff = :finite, inplacejac = false, kwargs...)
     r = f(p0)

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -16,26 +16,26 @@ StatsBase.residuals(lfr::LsqFitResult) = lfr.resid
 mse(lfr::LsqFitResult) = rss(lfr)/dof(lfr)
 
 # provide a method for those who have their own (non inplace) Jacobian function
-function lmfit(f, g, p0, wt; kwargs...)
+function lmfit(f, g, p0::AbstractArray, wt::AbstractArray; kwargs...)
     r = f(p0)
     R = OnceDifferentiable(f, g, p0, similar(r); inplace = false)
     lmfit(R, p0, wt; kwargs...)
 end
 
 #for inplace f and inplace g
-function lmfit(f!, g!, p0, wt, r; kwargs...)
+function lmfit(f!, g!, p0::AbstractArray, wt::AbstractArray, r::AbstractArray; kwargs...)
     R = OnceDifferentiable(f!, g!, p0, similar(r); inplace = true)
     lmfit(R, p0, wt; kwargs...)
 end
 
 #for inplace f only
-function lmfit(f!, p0, wt, r; autodiff = :finite, kwargs...)
+function lmfit(f!, p0, wt::AbstractArray, r::AbstractArray; autodiff = :finite, kwargs...)
     autodiff = autodiff == :forwarddiff ? :forward : autodiff
     R = OnceDifferentiable(f!, p0, similar(r); inplace = true, autodiff = autodiff)
     lmfit(R, p0, wt; kwargs...)
 end
 
-function lmfit(f, p0, wt; autodiff = :finite, kwargs...)
+function lmfit(f, p0::AbstractArray, wt::AbstractArray; autodiff = :finite, kwargs...)
     # this is a convenience function for the curve_fit() methods
     # which assume f(p) is the cost functionj i.e. the residual of a
     # model where
@@ -56,7 +56,7 @@ function lmfit(f, p0, wt; autodiff = :finite, kwargs...)
     lmfit(R, p0, wt; kwargs...)
 end
 
-function lmfit(R::OnceDifferentiable, p0, wt; autodiff = :finite, kwargs...)
+function lmfit(R::OnceDifferentiable, p0::AbstractArray, wt::AbstractArray; autodiff = :finite, kwargs...)
     results = levenberg_marquardt(R, p0; kwargs...)
     p = minimizer(results)
     return LsqFitResult(p, value!(R, p), jacobian!(R, p), converged(results), wt)
@@ -94,7 +94,7 @@ fit = curve_fit(model, xdata, ydata, p0)
 """
 function curve_fit end
 
-function curve_fit(model, xpts::AbstractArray, ydata::AbstractArray, p0; inplace = false, kwargs...)
+function curve_fit(model, xpts::AbstractArray, ydata::AbstractArray, p0::AbstractArray; inplace = false, kwargs...)
     # construct the cost function
     T = eltype(ydata)
 
@@ -108,7 +108,7 @@ function curve_fit(model, xpts::AbstractArray, ydata::AbstractArray, p0; inplace
 end
 
 function curve_fit(model, jacobian_model,
-            xpts::AbstractArray, ydata::AbstractArray, p0; inplace = false, kwargs...)
+            xpts::AbstractArray, ydata::AbstractArray, p0::AbstractArray; inplace = false, kwargs...)
 
     T = eltype(ydata)
 
@@ -123,7 +123,7 @@ function curve_fit(model, jacobian_model,
     end
 end
 
-function curve_fit(model, xpts::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0; inplace = false, kwargs...) where T
+function curve_fit(model, xpts::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0::AbstractArray; inplace = false, kwargs...) where T
     # construct a weighted cost function, with a vector weight for each ydata
     # for example, this might be wt = 1/sigma where sigma is some error term
     u = sqrt.(wt) # to be consistant with the matrix form

--- a/test/curve_fit_inplace.jl
+++ b/test/curve_fit_inplace.jl
@@ -70,34 +70,34 @@ let
 
     println("--------------\nPerformance of non-inplace")
     println("\t Evaluation function")
-    @time for i=range(0,50)
+    @time for i=range(0,stop=50,step=1)
         evalf(p0);
     end
 
     println("\t Jacobian function")
-    @time for i=range(0,50)
+    @time for i=range(0,stop=50,step=1)
         evalg(p0);
     end
 
     println("--------------\nPerformance of inplace")
     println("\t Evaluation function")
-    @time for i=range(0,50)
+    @time for i=range(0,stop=50,step=1)
         evalf_inplace(p0);
     end
 
     println("\t Jacobian function")
-    @time for i=range(0,50)
+    @time for i=range(0,stop=50,step=1)
         evalg_inplace(p0);
     end
 
     println("--------------\nPerformance of callable type")
     println("\t Evaluation function")
-    @time for i=range(0,50)
+    @time for i=range(0,stop=50,step=1)
         evalf_type(p0);
     end
 
     println("\t Jacobian function")
-    @time for i=range(0,50)
+    @time for i=range(0,stop=50,step=1)
         evalg_type(p0);
     end
 

--- a/test/curve_fit_inplace.jl
+++ b/test/curve_fit_inplace.jl
@@ -1,0 +1,147 @@
+struct Jacobian{T}
+   J::T
+end
+Jacobian(x, p) = Jacobian(zeros(eltype(x), length(x), length(p)))
+
+function (lj::Jacobian)(x,p)
+    J::Array{Float64,2} = lj.J
+    @. J[:,1] = exp(-x*p[2])
+    @. J[:,2] = -x*p[1]*J[:,1]
+    J
+end
+function f!_from_f(f, F::AbstractArray)
+    return function ff!(F, x)
+            copyto!(F, f(x))
+
+    end
+end
+let
+    # fitting noisy data to an exponential model
+    # TODO: Change to `.-x` when 0.5 support is dropped
+    model(x, p) = @. p[1] * exp(-x * p[2])
+
+    # some example data
+    Random.seed!(12345)
+    xdata = range(0, stop=10, length=500000)
+    ydata = model(xdata, [1.0, 2.0]) + 0.01*randn(length(xdata))
+    p0 = [0.5, 0.5]
+
+    # if your model is differentiable, it can be faster and/or more accurate
+    # to supply your own jacobian instead of using the finite difference
+    function jacobian_model(x,p)
+        J = Array{Float64}(undef, length(x), length(p))
+        @. J[:,1] = exp(-x*p[2])     #dmodel/dp[1]
+        @. J[:,2] = -x*p[1]*J[:,1]           #dmodel/dp[2]
+        J
+    end
+
+    function jacobian_model_inplace(J::Array{Float64,2},x,p)
+        @. J[:,1] = exp(-x*p[2])     #dmodel/dp[1]
+        @. J[:,2] = -x*p[1]*J[:,1]           #dmodel/dp[2]
+    end
+
+    jacobian_type = Jacobian(xdata, p0)
+
+    f(p) = model(xdata, p) - ydata
+    g(p) = jacobian_model(xdata, p)
+    df = OnceDifferentiable(f, g, p0, similar(ydata); inplace = false);
+    evalf(x) = NLSolversBase.value!!(df, x)
+    evalg(x) = NLSolversBase.jacobian!!(df, x)
+    r = evalf(p0);
+    j = evalg(p0);
+
+    f_inplace = f!_from_f(f,similar(ydata))
+    g_inplace = (G,p) -> jacobian_model_inplace(G, xdata, p)
+    df_inplace = OnceDifferentiable(f_inplace, g_inplace, p0, similar(ydata); inplace = true);
+    evalf_inplace(x) = NLSolversBase.value!!(df_inplace,x)
+    evalg_inplace(x) = NLSolversBase.jacobian!!(df_inplace,x)
+    r_inplace = evalf_inplace(p0);
+    j_inplace = evalg_inplace(p0);
+
+    f_type(p) = model(xdata, p) - ydata
+    df_type = OnceDifferentiable(f_type, p -> jacobian_type(xdata, p), p0, similar(ydata); inplace = false);
+    evalf_type(x) = NLSolversBase.value!!(df_type,x)
+    evalg_type(x) = NLSolversBase.jacobian!!(df_type,x)
+    r_type = evalf_type(p0);
+    j_type = evalg_type(p0);
+
+    @test r == r_inplace == r_type
+    @test j == j_inplace == j_type
+
+    println("--------------\nPerformance of non-inplace")
+    println("\t Evaluation function")
+    @time for i=range(0,50)
+        evalf(p0);
+    end
+
+    println("\t Jacobian function")
+    @time for i=range(0,50)
+        evalg(p0);
+    end
+
+    println("--------------\nPerformance of inplace")
+    println("\t Evaluation function")
+    @time for i=range(0,50)
+        evalf_inplace(p0);
+    end
+
+    println("\t Jacobian function")
+    @time for i=range(0,50)
+        evalg_inplace(p0);
+    end
+
+    println("--------------\nPerformance of callable type")
+    println("\t Evaluation function")
+    @time for i=range(0,50)
+        evalf_type(p0);
+    end
+
+    println("\t Jacobian function")
+    @time for i=range(0,50)
+        evalg_type(p0);
+    end
+
+
+    curve_fit(model, jacobian_model, xdata, ydata, p0); #warmup
+    curve_fit(model, jacobian_model_inplace, xdata, ydata, p0; inplacejac = true);
+    curve_fit(model, (x,p)-> jacobian_type(x,p), xdata, ydata, p0);
+
+    println("--------------\nPerformance of curve_fit")
+
+    println("\t Non-inplace")
+    jacobian_fit = @time curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=100)
+    @test jacobian_fit.converged
+
+    println("\t Inplace")
+    jacobian_fit_inplace = @time curve_fit(model, jacobian_model_inplace, xdata, ydata, p0; inplacejac = true, maxIter=100)
+    @test jacobian_fit_inplace.converged
+
+    println("\t Callable type")
+    jacobian_fit_type = @time curve_fit(model, (x,p)-> jacobian_type(x,p), xdata, ydata, p0; maxIter=100)
+    @test jacobian_fit_type.converged
+
+    @test jacobian_fit.param == jacobian_fit_inplace.param == jacobian_fit_type.param
+    # some example data
+    yvars = 1e-6*rand(length(xdata))
+    ydata = model(xdata, [1.0, 2.0]) + sqrt.(yvars) .* randn(length(xdata))
+
+    println("--------------\nPerformance of curve_fit with weights")
+
+    curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, [0.5, 0.5]);
+    curve_fit(model, jacobian_model_inplace, xdata, ydata, 1 ./ yvars, [0.5, 0.5]; inplacejac = true);
+    curve_fit(model, (x,p)-> jacobian_type(x,p), xdata, ydata, 1 ./ yvars, [0.5, 0.5]);
+
+    println("\t Non-inplace with weights")
+    fit = @time curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, [0.5, 0.5]; maxIter=100)
+    @test fit.converged
+
+    println("\t Inplace with weights")
+    fit_inplace = @time curve_fit(model, jacobian_model_inplace, xdata, ydata, 1 ./ yvars, [0.5, 0.5]; inplacejac = true, maxIter=100)
+    @test fit_inplace.converged
+
+    println("\t Callable type with weights")
+    fit_type = @time curve_fit(model, (x,p)-> jacobian_type(x,p), xdata, ydata, 1 ./ yvars, [0.5, 0.5]; maxIter=100)
+    @test fit_type.converged
+
+    @test fit.param == fit_inplace.param == fit_type.param
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using LsqFit, Test, LinearAlgebra, Random
 using OptimBase, Calculus
 import NLSolversBase: OnceDifferentiable
 
-my_tests = [ "curve_fit.jl", "levenberg_marquardt.jl"]
+my_tests = ["curve_fit.jl", "levenberg_marquardt.jl", "curve_fit_inplace.jl"]
 
 println("Running tests:")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 #
 # Correctness Tests
 #
-
+push!(LOAD_PATH, ".")
 using LsqFit, Test, LinearAlgebra, Random
 using OptimBase, Calculus
 import NLSolversBase: OnceDifferentiable

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 #
 # Correctness Tests
 #
-push!(LOAD_PATH, ".")
 using LsqFit, Test, LinearAlgebra, Random
 using OptimBase, Calculus
 import NLSolversBase: OnceDifferentiable


### PR DESCRIPTION
I also set up some tests in `test/curve_fit_inplace.jl`, for the sake of legibility (although they could be moved to `test/curve_fit.jl`) along with some small performance comparisons since it's the primary motivator. 

The syntax goes as `curve_fit(model, inplace_jacob, xdata, ydata; inplacejac = true)` or `curve_fit(model, inplace_jacob, xdata, ydata, weights; inplacejac = true)`

Thenext logical steps would be:
- support for covariate input
- ~support for an `inplacemodel` option~

Extract of the benchmarks:
```
Performance of curve_fit
         Non-inplace
  3.425112 seconds (164.67 k allocations: 2.542 GiB, 9.32% gc time)
         Inplace
  2.976785 seconds (9.62 k allocations: 1.938 GiB, 8.68% gc time)
         Callable type
  3.066315 seconds (5.37 k allocations: 1.937 GiB, 8.44% gc time)
--------------
Performance of curve_fit with weights
         Non-inplace with weights
  4.137499 seconds (105.40 k allocations: 3.618 GiB, 11.56% gc time)
         Inplace with weights
  3.560014 seconds (63.90 k allocations: 2.424 GiB, 10.21% gc time)
         Callable type with weights
  3.955812 seconds (387.80 k allocations: 3.036 GiB, 11.01% gc time)
```

(seems to particularly improve on callable type in the weighted case)
