### PR TITLE
Geodesic acceleration

### DIFF
--- a/src/LsqFit.jl
+++ b/src/LsqFit.jl
@@ -15,8 +15,6 @@ module LsqFit
     import NLSolversBase: value, jacobian
     import StatsBase
     import StatsBase: coef, dof, nobs, rss, stderror, weights, residuals
-    
-
 
     import Base.summary
 

--- a/src/LsqFit.jl
+++ b/src/LsqFit.jl
@@ -5,6 +5,8 @@ module LsqFit
            margin_error,
            confidence_interval,
            estimate_covar,
+           make_hessian,
+           Avv,
            # StatsBase reexports
            dof, coef, nobs, mse, rss,
            stderror, weights, residuals
@@ -12,6 +14,7 @@ module LsqFit
     using Distributions
     using OptimBase
     using LinearAlgebra
+    using ForwardDiff
     import NLSolversBase: value, jacobian
     import StatsBase
     import StatsBase: coef, dof, nobs, rss, stderror, weights, residuals

--- a/src/LsqFit.jl
+++ b/src/LsqFit.jl
@@ -15,9 +15,12 @@ module LsqFit
     import NLSolversBase: value, jacobian
     import StatsBase
     import StatsBase: coef, dof, nobs, rss, stderror, weights, residuals
+    
+
 
     import Base.summary
 
+    include("geodesic.jl")
     include("levenberg_marquardt.jl")
     include("curve_fit.jl")
 

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -113,6 +113,7 @@ function curve_fit(model::Function, jacobian_model::Function,
     lmfit(f, g, p0, T[]; kwargs...)
 end
 
+#geodesic
 function curve_fit(model::Function, jacobian_model::Function, avv!::Function,
             xpts::AbstractArray, ydata::AbstractArray, p0; kwargs...)
 

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -113,17 +113,6 @@ function curve_fit(model::Function, jacobian_model::Function,
     lmfit(f, g, p0, T[]; kwargs...)
 end
 
-#geodesic
-function curve_fit(model::Function, jacobian_model::Function, avv!::Function,
-            xpts::AbstractArray, ydata::AbstractArray, p0; kwargs...)
-
-    T = eltype(ydata)
-
-    f = (p) -> model(xpts, p) - ydata
-    g = (p) -> jacobian_model(xpts, p)
-    lmfit(f, g, avv!, p0, T[]; kwargs...)
-end
-
 function curve_fit(model::Function, xpts::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0; kwargs...) where T
     # construct a weighted cost function, with a vector weight for each ydata
     # for example, this might be wt = 1/sigma where sigma is some error term

--- a/src/geodesic.jl
+++ b/src/geodesic.jl
@@ -1,11 +1,63 @@
-function vHv!(hessians,v,dir_deriv)
+# see related https://discourse.julialang.org/t/nested-forwarddiff-jacobian-calls-with-inplace-function/21232/7
+function make_out_of_place_func(f!, x, make_buffer)
+    y = make_buffer(f!, x) # make_buffer overloads will be defined below
+    x -> f!(y, x)
+end
+
+struct OutOfPlace{F}
+    f!::F
+    out_of_place_funcs::Dict{Type, Function}
+    make_buffer::Function
+    
+    function OutOfPlace(f!::T, dict, shape::Tuple) where T
+        
+        mk(::T, p) = similar(p, shape)
+        new{T}(f!, dict, mk)
+    end
+end
+
+OutOfPlace(f!, shape) = OutOfPlace(f!, Dict{Type, Function}(), shape)
+
+eval_f(f::F, x) where {F} = f(x) # function barrier
+function (oop::OutOfPlace{F})(x) where {F}
+    T = eltype(x)
+    f = get!(() -> make_out_of_place_func(oop.f!, x, oop.make_buffer), oop.out_of_place_funcs, T)
+    eval_f(f, x)
+end
+
+
+
+function make_hessian(f!,x0,p0)
+    
+    f = OutOfPlace(f!, (length(x0),))
+    g! = (outjac, p) -> (ForwardDiff.jacobian!(outjac, f, p); outjac = outjac')
+    g = OutOfPlace(g!,(length(x0),length(p0)))
+    h! = (outjac2, p) -> (ForwardDiff.jacobian!(outjac2, g, p); reshape(outjac2',length(p0),length(p0),length(x0)))
+    h!
+end
+
+struct Avv
+	h!::Function
+    hessians::Array{Float64}
+    
+    function Avv(h!::Function, n::Int, m::Int)
+    	hessians = Array{Float64}(undef, m*n, n)
+        new(h!, hessians)
+    end
+end
+
+function (avv::Avv)(p::AbstractVector, v::AbstractVector, dir_deriv::AbstractVector)
+    hess = avv.h!(avv.hessians, p) #half of the runtime
+    vHv!(hess,v,dir_deriv) #half of the runtime, almost all the memory
+end
+
+function vHv!(hessians::AbstractArray,v::AbstractVector,dir_deriv::AbstractVector)
     tmp = similar(v) #v shouldn't be too large in general, so I kept it here
     vt = v'
     
     for i=1:length(dir_deriv)
-        @views mul!(tmp, hessians[:,:,i], v)
+        @views mul!(tmp, hessians[:,:,i], v) #this line is particularly expensive
         dir_deriv[i] = vt*tmp
     end
     
-end 
-
+end

--- a/src/geodesic.jl
+++ b/src/geodesic.jl
@@ -1,4 +1,4 @@
-function getvHv!(hessians,v,dir_deriv)
+function vHv!(hessians,v,dir_deriv)
     tmp = similar(v) #v shouldn't be too large in general, so I kept it here
     vt = v'
     
@@ -9,7 +9,3 @@ function getvHv!(hessians,v,dir_deriv)
     
 end 
 
-function Avv!(h!,p,v,dir_deriv,hessians)
-    h!(p,hessians)
-    getvHv!(hessians,v,dir_deriv)
-end

--- a/src/geodesic.jl
+++ b/src/geodesic.jl
@@ -1,0 +1,15 @@
+function getvHv!(hessians,v,dir_deriv)
+    tmp = similar(v) #v shouldn't be too large in general, so I kept it here
+    vt = v'
+    
+    for i=1:length(dir_deriv)
+        @views mul!(tmp, hessians[:,:,i], v)
+        dir_deriv[i] = vt*tmp
+    end
+    
+end 
+
+function Avv!(h!,p,v,dir_deriv,hessians)
+    h!(p,hessians)
+    getvHv!(hessians,v,dir_deriv)
+end

--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -34,7 +34,7 @@ function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T
     x_tol::Real = 1e-8, g_tol::Real = 1e-12, maxIter::Integer = 1000,
     lambda::Real = 10.0, lambda_increase::Real = 10., lambda_decrease::Real = 0.1,
     min_step_quality::Real = 1e-3, good_step_quality::Real = 0.75,
-    show_trace::Bool = false, lower::Vector{T} = Array{T}(undef, 0), upper::Vector{T} = Array{T}(undef, 0), avv!::Union{Function,Nothing} = nothing
+    show_trace::Bool = false, lower::Vector{T} = Array{T}(undef, 0), upper::Vector{T} = Array{T}(undef, 0), avv!::Union{Function,Nothing,Avv} = nothing
     ) where T
 
     # Create residual and jacobian evaluators, should be inplace
@@ -90,6 +90,7 @@ function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T
         println(os)
     end
     local J
+
     while (~converged && iterCt < maxIter)
         if need_jacobian
             J = g(x)
@@ -194,7 +195,6 @@ function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T
         end
         converged = g_converged | x_converged
     end
-    println("Num iter:",iterCt," geo:",avv! != nothing," res:",residual)
 
     MultivariateOptimizationResults(
         LevenbergMarquardt(),    # method

--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -191,6 +191,11 @@ function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T
     )
 end
 
+#I had to copy lm, just out of convinience, to get things working
+# I think a smarted way to do this *might* be to create a type similar to `OnceDifferentiable` 
+# and the like. This way we could not only merge the two functions, but also have a convinient
+# way to provide an autodiff-made acceleration when someone doesn't provide an `avv`.
+# it would probably be very inefficient performace-wise for most cases, but it wouldn't hurt to have it somewhere
 function levenberg_marquardt(df::OnceDifferentiable, avv!::Function, initial_x::AbstractVector{T};
     x_tol::Real = 1e-8, g_tol::Real = 1e-12, maxIter::Integer = 1000,
     lambda::Real = 10.0, lambda_increase::Real = 10., lambda_decrease::Real = 0.1,
@@ -281,10 +286,12 @@ function levenberg_marquardt(df::OnceDifferentiable, avv!::Function, initial_x::
 
         v = JJ \ n_buffer
 
+        #GEODESIC ACCELERATION PART
         avv!(x, v, dir_deriv)
         mul!(a, transpose(J), dir_deriv)
         a = JJ \ a
         rmul!(a, -0.5)
+        #end of the GEODESIC ACCELERATION PART
             
         delta_x = v + a
         println("a:",a)

--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -191,7 +191,7 @@ function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T
     )
 end
 
-function levenberg_marquardt(df::OnceDifferentiable, h!::Function, initial_x::AbstractVector{T};
+function levenberg_marquardt(df::OnceDifferentiable, avv!::Function, initial_x::AbstractVector{T};
     x_tol::Real = 1e-8, g_tol::Real = 1e-12, maxIter::Integer = 1000,
     lambda::Real = 10.0, lambda_increase::Real = 10., lambda_decrease::Real = 0.1,
     min_step_quality::Real = 1e-3, good_step_quality::Real = 0.75,
@@ -238,9 +238,7 @@ function levenberg_marquardt(df::OnceDifferentiable, h!::Function, initial_x::Ab
     m = length(fcur)
     JJ = Matrix{T}(undef, n, n)
     n_buffer = Vector{T}(undef, n)
-    Jdelta_buffer = similar(fcur)
     dir_deriv = Array{T}(undef,m)
-    hessians = Array{T}(undef, n, n, m)
 
     # Maintain a trace of the system.
     tr = OptimizationTrace{LevenbergMarquardt}()
@@ -283,7 +281,7 @@ function levenberg_marquardt(df::OnceDifferentiable, h!::Function, initial_x::Ab
 
         v = JJ \ n_buffer
 
-        Avv!(h!, x, v, dir_deriv, hessians)
+        avv!(x, v, dir_deriv)
         mul!(a, transpose(J), dir_deriv)
         a = JJ \ a
         rmul!(a, -0.5)
@@ -305,9 +303,7 @@ function levenberg_marquardt(df::OnceDifferentiable, h!::Function, initial_x::Ab
         end
 
         # if the linear assumption is valid, our new residual should be:
-        mul!(Jdelta_buffer,J,delta_x)
-        @. Jdelta_buffer = Jdelta_buffer + fcur
-        predicted_residual = sum(abs2, Jdelta_buffer)
+        predicted_residual = sum(abs2, J*delta_x + fcur)
         
   
 

--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -25,182 +25,16 @@ Comp & Applied Math).
 * `show_trace::Bool=false`: print a status summary on each iteration if true
 * `lower,upper=[]`: bound solution to these limits
 """
-function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T};
-    x_tol::Real = 1e-8, g_tol::Real = 1e-12, maxIter::Integer = 1000,
-    lambda::Real = 10.0, lambda_increase::Real = 10., lambda_decrease::Real = 0.1,
-    min_step_quality::Real = 1e-3, good_step_quality::Real = 0.75,
-    show_trace::Bool = false, lower::Vector{T} = Array{T}(undef, 0), upper::Vector{T} = Array{T}(undef, 0)
-    ) where T
 
-    # Create residual and jacobian evaluators, should be inplace
-    f = x -> NLSolversBase.value!(df, x)
-    g = x -> NLSolversBase.jacobian!(df, x)
-
-    # check parameters
-    ((isempty(lower) || length(lower)==length(initial_x)) && (isempty(upper) || length(upper)==length(initial_x))) ||
-            throw(ArgumentError("Bounds must either be empty or of the same length as the number of parameters."))
-    ((isempty(lower) || all(initial_x .>= lower)) && (isempty(upper) || all(initial_x .<= upper))) ||
-            throw(ArgumentError("Initial guess must be within bounds."))
-    (0 <= min_step_quality < 1) || throw(ArgumentError(" 0 <= min_step_quality < 1 must hold."))
-    (0 < good_step_quality <= 1) || throw(ArgumentError(" 0 < good_step_quality <= 1 must hold."))
-    (min_step_quality < good_step_quality) || throw(ArgumentError("min_step_quality < good_step_quality must hold."))
-
-
-    # other constants
-    MAX_LAMBDA = 1e16 # minimum trust region radius
-    MIN_LAMBDA = 1e-16 # maximum trust region radius
-    MIN_DIAGONAL = 1e-6 # lower bound on values of diagonal matrix used to regularize the trust region step
-
-
-    converged = false
-    x_converged = false
-    g_converged = false
-    need_jacobian = true
-    iterCt = 0
-    x = copy(initial_x)
-    delta_x = copy(initial_x)
-    f_calls = 0
-    g_calls = 0
-
-    fcur = f(x)
-    f_calls += 1
-    residual = sum(abs2, fcur)
-
-    # Create buffers
-    n = length(x)
-    JJ = Matrix{T}(undef, n, n)
-    n_buffer = Vector{T}(undef, n)
-
-    # Maintain a trace of the system.
-    tr = OptimizationTrace{LevenbergMarquardt}()
-    if show_trace
-        d = Dict("lambda" => lambda)
-        os = OptimizationState{LevenbergMarquardt}(iterCt, sum(abs2, fcur), NaN, d)
-        push!(tr, os)
-        println(os)
-    end
-
-    local J
-    while (~converged && iterCt < maxIter)
-        if need_jacobian
-            J = g(x)
-            g_calls += 1
-            need_jacobian = false
-        end
-        # we want to solve:
-        #    argmin 0.5*||J(x)*delta_x + f(x)||^2 + lambda*||diagm(J'*J)*delta_x||^2
-        # Solving for the minimum gives:
-        #    (J'*J + lambda*diagm(DtD)) * delta_x == -J' * f(x), where DtD = sum(abs2, J,1)
-        # Where we have used the equivalence: diagm(J'*J) = diagm(sum(abs2, J,1))
-        # It is additionally useful to bound the elements of DtD below to help
-        # prevent "parameter evaporation".
-        DtD = vec(sum(abs2, J, dims=1))
-        for i in 1:length(DtD)
-            if DtD[i] <= MIN_DIAGONAL
-                DtD[i] = MIN_DIAGONAL
-            end
-        end
-        # delta_x = ( J'*J + lambda * Diagonal(DtD) ) \ ( -J'*fcur )
-        mul!(JJ, transpose(J), J)
-        @simd for i in 1:n
-            @inbounds JJ[i, i] += lambda * DtD[i]
-        end
-        mul!(n_buffer, transpose(J), fcur)
-        rmul!(n_buffer, -1)
-        delta_x = JJ \ n_buffer
-
-        # apply box constraints
-        if !isempty(lower)
-            @simd for i in 1:n
-               @inbounds delta_x[i] = max(x[i] + delta_x[i], lower[i]) - x[i]
-            end
-        end
-        if !isempty(upper)
-            @simd for i in 1:n
-               @inbounds delta_x[i] = min(x[i] + delta_x[i], upper[i]) - x[i]
-            end
-        end
-
-        # if the linear assumption is valid, our new residual should be:
-        predicted_residual = sum(abs2, J*delta_x + fcur)
-
-        # try the step and compute its quality
-        trial_f = f(x + delta_x)
-        f_calls += 1
-        trial_residual = sum(abs2, trial_f)
-        # step quality = residual change / predicted residual change
-        rho = (trial_residual - residual) / (predicted_residual - residual)
-        if rho > min_step_quality
-            x += delta_x
-            fcur = trial_f
-            residual = trial_residual
-            if rho > good_step_quality
-                # increase trust region radius
-                lambda = max(lambda_decrease*lambda, MIN_LAMBDA)
-            end
-            need_jacobian = true
-        else
-            # decrease trust region radius
-            lambda = min(lambda_increase*lambda, MAX_LAMBDA)
-        end
-        iterCt += 1
-
-        # show state
-        if show_trace
-            g_norm = norm(J' * fcur, Inf)
-            d = Dict("g(x)" => g_norm, "dx" => delta_x, "lambda" => lambda)
-            os = OptimizationState{LevenbergMarquardt}(iterCt, sum(abs2, fcur), g_norm, d)
-            push!(tr, os)
-            println(os)
-        end
-
-        # check convergence criteria:
-        # 1. Small gradient: norm(J^T * fcur, Inf) < g_tol
-        # 2. Small step size: norm(delta_x) < x_tol
-        if norm(J' * fcur, Inf) < g_tol
-            g_converged = true
-        elseif norm(delta_x) < x_tol*(x_tol + norm(x))
-            x_converged = true
-        end
-        converged = g_converged | x_converged
-    end
-
-    println("Num iter:",iterCt," geo: false")
-
-    MultivariateOptimizationResults(
-        LevenbergMarquardt(),    # method
-        initial_x,             # initial_x
-        x,                     # minimizer
-        sum(abs2, fcur),       # minimum
-        iterCt,                # iterations
-        !converged,            # iteration_converged
-        x_converged,           # x_converged
-        0.0,                   # x_tol
-        0.0,
-        false,                 # f_converged
-        0.0,                   # f_tol
-        0.0,
-        g_converged,           # g_converged
-        g_tol,                  # g_tol
-        0.0,
-        false,                 # f_increased
-        tr,                    # trace
-        f_calls,               # f_calls
-        g_calls,               # g_calls
-        0                      # h_calls
-    )
-end
-
-#I had to copy lm, just out of convinience, to get things working
 # I think a smarted way to do this *might* be to create a type similar to `OnceDifferentiable` 
 # and the like. This way we could not only merge the two functions, but also have a convinient
 # way to provide an autodiff-made acceleration when someone doesn't provide an `avv`.
 # it would probably be very inefficient performace-wise for most cases, but it wouldn't hurt to have it somewhere
-function levenberg_marquardt(df::OnceDifferentiable, avv!::Function, initial_x::AbstractVector{T};
+function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T};
     x_tol::Real = 1e-8, g_tol::Real = 1e-12, maxIter::Integer = 1000,
     lambda::Real = 10.0, lambda_increase::Real = 10., lambda_decrease::Real = 0.1,
     min_step_quality::Real = 1e-3, good_step_quality::Real = 0.75,
-    show_trace::Bool = false, lower::Vector{T} = Array{T}(undef, 0), upper::Vector{T} = Array{T}(undef, 0) 
+    show_trace::Bool = false, lower::Vector{T} = Array{T}(undef, 0), upper::Vector{T} = Array{T}(undef, 0), avv!::Union{Function,Nothing} = nothing
     ) where T
 
     # Create residual and jacobian evaluators, should be inplace
@@ -286,15 +120,22 @@ function levenberg_marquardt(df::OnceDifferentiable, avv!::Function, initial_x::
 
         v = JJ \ n_buffer
 
-        #GEODESIC ACCELERATION PART
-        avv!(x, v, dir_deriv)
-        mul!(a, transpose(J), dir_deriv)
-        a = JJ \ a
-        rmul!(a, -0.5)
-        #end of the GEODESIC ACCELERATION PART
+        
+        if avv! != nothing
+            #GEODESIC ACCELERATION PART
+            avv!(x, v, dir_deriv)
+            mul!(a, transpose(J), dir_deriv)
+            a = JJ \ a # we multiply by g^-1
+            rmul!(a, -0.5)
+            delta_x = v + a
+            println("a:",a)
+            #end of the GEODESIC ACCELERATION PART
+        else
+            delta_x = v
+        end
+        
             
-        delta_x = v + a
-        println("a:",a)
+        
         
 
         # apply box constraints
@@ -356,7 +197,7 @@ function levenberg_marquardt(df::OnceDifferentiable, avv!::Function, initial_x::
         converged = g_converged | x_converged 
     end
     
-    println("Num iter:",iterCt," geo: true")
+    println("Num iter:",iterCt," geo:",avv! != nothing)
 
     MultivariateOptimizationResults(
         LevenbergMarquardt(),    # method

--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -124,11 +124,11 @@ function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T
         
         if avv! != nothing
             #GEODESIC ACCELERATION PART
-            avv!(x, v, dir_deriv)
+            avv!(dir_deriv, x, v)
             mul!(a, transpose(J), dir_deriv)
             rmul!(a, -1) #we multiply by -1 before the decomposition/division
             LAPACK.potrf!('U', JJ) #in place cholesky decomposition
-            LAPACK.potrs!('U', JJ, a) #in short divides a by JJ, taking into account the fact that JJ is now the `U` cholesky decoposition of what it was before
+            LAPACK.potrs!('U', JJ, a) #divides a by JJ, taking into account the fact that JJ is now the `U` cholesky decoposition of what it was before
             rmul!(a, 0.5)
             delta_x = v + a
             #end of the GEODESIC ACCELERATION PART

--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -78,6 +78,7 @@ function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T
     JJ = Matrix{T}(undef, n, n)
     n_buffer = Vector{T}(undef, n)
     Jdelta_buffer = similar(fcur)
+
     dir_deriv = Array{T}(undef,m)
 
     # Maintain a trace of the system.
@@ -88,7 +89,6 @@ function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T
         push!(tr, os)
         println(os)
     end
-   
     local J
     while (~converged && iterCt < maxIter)
         if need_jacobian

--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -165,6 +165,8 @@ function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T
         converged = g_converged | x_converged
     end
 
+    println("Num iter:",iterCt," geo: false")
+
     MultivariateOptimizationResults(
         LevenbergMarquardt(),    # method
         initial_x,             # initial_x
@@ -176,6 +178,195 @@ function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T
         0.0,                   # x_tol
         0.0,
         false,                 # f_converged
+        0.0,                   # f_tol
+        0.0,
+        g_converged,           # g_converged
+        g_tol,                  # g_tol
+        0.0,
+        false,                 # f_increased
+        tr,                    # trace
+        f_calls,               # f_calls
+        g_calls,               # g_calls
+        0                      # h_calls
+    )
+end
+
+function levenberg_marquardt(df::OnceDifferentiable, h!::Function, initial_x::AbstractVector{T};
+    x_tol::Real = 1e-8, g_tol::Real = 1e-12, maxIter::Integer = 1000,
+    lambda::Real = 10.0, lambda_increase::Real = 10., lambda_decrease::Real = 0.1,
+    min_step_quality::Real = 1e-3, good_step_quality::Real = 0.75,
+    show_trace::Bool = false, lower::Vector{T} = Array{T}(undef, 0), upper::Vector{T} = Array{T}(undef, 0) 
+    ) where T
+
+    # Create residual and jacobian evaluators, should be inplace
+    f = x -> NLSolversBase.value!(df, x)
+    g = x -> NLSolversBase.jacobian!(df, x)
+
+    # check parameters
+    ((isempty(lower) || length(lower)==length(initial_x)) && (isempty(upper) || length(upper)==length(initial_x))) ||
+            throw(ArgumentError("Bounds must either be empty or of the same length as the number of parameters."))
+    ((isempty(lower) || all(initial_x .>= lower)) && (isempty(upper) || all(initial_x .<= upper))) ||
+            throw(ArgumentError("Initial guess must be within bounds."))
+    (0 <= min_step_quality < 1) || throw(ArgumentError(" 0 <= min_step_quality < 1 must hold."))
+    (0 < good_step_quality <= 1) || throw(ArgumentError(" 0 < good_step_quality <= 1 must hold."))
+    (min_step_quality < good_step_quality) || throw(ArgumentError("min_step_quality < good_step_quality must hold."))
+
+
+    # other constants
+    MAX_LAMBDA = 1e16 # minimum trust region radius
+    MIN_LAMBDA = 1e-16 # maximum trust region radius
+    MIN_DIAGONAL = 1e-6 # lower bound on values of diagonal matrix used to regularize the trust region step
+
+
+    converged = false
+    x_converged = false
+    g_converged = false
+    need_jacobian = true
+    iterCt = 0
+    x = copy(initial_x)
+    delta_x = copy(initial_x)
+    a = similar(x)
+    f_calls = 0
+    g_calls = 0
+
+    fcur = f(x)
+    f_calls += 1
+    residual = sum(abs2, fcur)
+
+    # Create buffers
+    n = length(x)
+    m = length(fcur)
+    JJ = Matrix{T}(undef, n, n)
+    n_buffer = Vector{T}(undef, n)
+    Jdelta_buffer = similar(fcur)
+    dir_deriv = Array{T}(undef,m)
+    hessians = Array{T}(undef, n, n, m)
+
+    # Maintain a trace of the system.
+    tr = OptimizationTrace{LevenbergMarquardt}()
+    if show_trace
+        d = Dict("lambda" => lambda)
+        os = OptimizationState{LevenbergMarquardt}(iterCt, sum(abs2, fcur), NaN, d)
+        push!(tr, os)
+        println(os)
+    end
+    
+    local J
+    while (~converged && iterCt < maxIter)
+        if need_jacobian
+            J = g(x)
+            g_calls += 1
+            need_jacobian = false
+        end
+        # we want to solve:
+        #    argmin 0.5*||J(x)*delta_x + f(x)||^2 + lambda*||diagm(J'*J)*delta_x||^2
+        # Solving for the minimum gives:
+        #    (J'*J + lambda*diagm(DtD)) * delta_x == -J' * f(x), where DtD = sum(abs2, J,1)
+        # Where we have used the equivalence: diagm(J'*J) = diagm(sum(abs2, J,1))
+        # It is additionally useful to bound the elements of DtD below to help
+        # prevent "parameter evaporation".
+        
+        DtD = vec(sum(abs2, J, dims=1))
+        for i in 1:length(DtD)
+            if DtD[i] <= MIN_DIAGONAL
+                DtD[i] = MIN_DIAGONAL
+            end
+        end
+        # delta_x = ( J'*J + lambda * Diagonal(DtD) ) \ ( -J'*fcur )
+        mul!(JJ, transpose(J), J)
+        @simd for i in 1:n
+            @inbounds JJ[i, i] += lambda * DtD[i]
+        end
+        #n_buffer is delta C, JJ is g
+        mul!(n_buffer, transpose(J), fcur)
+        rmul!(n_buffer, -1)
+
+        v = JJ \ n_buffer
+
+        Avv!(h!, x, v, dir_deriv, hessians)
+        mul!(a, transpose(J), dir_deriv)
+        a = JJ \ a
+        rmul!(a, -0.5)
+            
+        delta_x = v + a
+        println("a:",a)
+        
+
+        # apply box constraints
+        if !isempty(lower)
+            @simd for i in 1:n
+               @inbounds delta_x[i] = max(x[i] + delta_x[i], lower[i]) - x[i]
+            end
+        end
+        if !isempty(upper)
+            @simd for i in 1:n
+               @inbounds delta_x[i] = min(x[i] + delta_x[i], upper[i]) - x[i]
+            end
+        end
+
+        # if the linear assumption is valid, our new residual should be:
+        mul!(Jdelta_buffer,J,delta_x)
+        @. Jdelta_buffer = Jdelta_buffer + fcur
+        predicted_residual = sum(abs2, Jdelta_buffer)
+        
+  
+
+        # try the step and compute its quality
+        trial_f = f(x + delta_x)
+        f_calls += 1
+        trial_residual = sum(abs2, trial_f)
+        # step quality = residual change / predicted residual change
+        rho = (trial_residual - residual) / (predicted_residual - residual)
+        if rho > min_step_quality
+            x += delta_x
+            fcur = trial_f
+            residual = trial_residual
+            if rho > good_step_quality
+                # increase trust region radius
+                lambda = max(lambda_decrease*lambda, MIN_LAMBDA)
+            end
+            need_jacobian = true
+        else
+            # decrease trust region radius
+            lambda = min(lambda_increase*lambda, MAX_LAMBDA)
+        end
+        iterCt += 1
+
+        # show state
+        if show_trace
+            g_norm = norm(J' * fcur, Inf)
+            d = Dict("g(x)" => g_norm, "dx" => delta_x, "lambda" => lambda)
+            os = OptimizationState{LevenbergMarquardt}(iterCt, sum(abs2, fcur), g_norm, d)
+            push!(tr, os)
+            println(os)
+        end
+
+        # check convergence criteria:
+        # 1. Small gradient: norm(J^T * fcur, Inf) < g_tol
+        # 2. Small step size: norm(delta_x) < x_tol
+
+        if norm(J' * fcur, Inf) < g_tol
+            g_converged = true
+        elseif norm(delta_x) < x_tol*(x_tol + norm(x))
+            x_converged = true
+        end
+        converged = g_converged | x_converged 
+    end
+    
+    println("Num iter:",iterCt," geo: true")
+
+    MultivariateOptimizationResults(
+        LevenbergMarquardt(),    # method
+        initial_x,             # initial_x
+        x,                     # minimizer
+        sum(abs2, fcur),       # minimum
+        iterCt,                # iterations
+        !converged,            # iteration_converged
+        x_converged,           # x_converged
+        0.0,                   # x_tol
+        0.0,
+        false,                 # f_converged
+
         0.0,                   # f_tol
         0.0,
         g_converged,           # g_converged

--- a/test/geodesic.jl
+++ b/test/geodesic.jl
@@ -1,0 +1,51 @@
+let
+    # fitting noisy data to an exponential model
+    model(x, p) = @. p[1] * exp(-x * p[2])
+
+    # some example data
+    Random.seed!(12345)
+    xdata = range(0, stop=10, length=50000)
+    ydata = model(xdata, [1.0, 2.0]) + 0.01*randn(length(xdata))
+    p0 = [20., 20.]
+
+    # if your model is differentiable, it can be faster and/or more accurate
+    # to supply your own jacobian instead of using the finite difference
+    function jacobian_model(x,p)
+        J = Array{Float64}(undef, length(x), length(p))
+        @. J[:,1] = exp(-x*p[2])     #dmodel/dp[1]
+        @. @views J[:,2] = -x*p[1]*J[:,1] 
+        J
+    end
+
+    # a couple notes on the h function
+    # - "h" refers to the function, hessians to the array of hessians
+    # - we "embed/bake" xdate into function, since we care about the derivatives in "p", always evaluated at the xdata points
+    function h!(p,hessians) 
+        for i=1:length(xdata)
+            hessians[1,1,i] = 0 #Do NOT allocate H with a whole matrix: H = [a b; b c], this would take a lot of memory
+            hessians[1,2,i] = (-xdata[i] * exp(-xdata[i] * p[2]))
+            hessians[2,1,i] = (-xdata[i] * exp(-xdata[i] * p[2]))
+            hessians[2,2,i] = (xdata[i]^2 * p[1] * exp(-xdata[i] * p[2]))
+        end
+    end
+
+
+    curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=1); #warmup
+    curve_fit(model, jacobian_model, h!, xdata, ydata, p0; maxIter=1);
+
+    println("--------------\nPerformance of curve_fit vs geo")
+
+    println("\t Non-inplace")
+    fit = @time curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=100)
+    @test fit.converged
+
+
+    println("\t Geodesic")
+    fit_geo = @time curve_fit(model, jacobian_model, h!, xdata, ydata, p0; maxIter=100)
+    @test fit_geo.converged
+
+    @test maximum(fit.param-fit_geo.param) < 1e-8
+
+
+end
+

--- a/test/geodesic.jl
+++ b/test/geodesic.jl
@@ -1,5 +1,3 @@
-using BenchmarkTools
-
 let
     
 

--- a/test/geodesic.jl
+++ b/test/geodesic.jl
@@ -30,7 +30,7 @@ let
     # - the basic idea is to see the model output as simply a collection of functions: f1...fm
     # - then Avv return an array of size m, where each elements corresponds to
     # v'H(p)v, with H an n*n Hessian matrix of the m-th function, with n the size of p
-    function manual_avv!(p,v,dir_deriv)
+    function manual_avv!(dir_deriv,p,v)
         v1 = v[1]
         v2 = v[2]
         for i=1:length(xdata)

--- a/test/geodesic.jl
+++ b/test/geodesic.jl
@@ -21,21 +21,26 @@ let
     # - the basic idea is to see the model output as simply a collection of functions: f1...fm
     # - then Avv return an array of size m, where each elements corresponds to
     # v'H(p)v, with H an n*n Hessian matrix of the m-th function, with n the size of p
-    function Avv(p,v,dir_deriv)
+    function Avv!(p,v,dir_deriv)
         for i=1:length(xdata)
+            #compute all the elements of the H matrix
             h11 = 0
             h12 = (-xdata[i] * exp(-xdata[i] * p[2]))
             #h21 = h12
             h22 = (xdata[i]^2 * p[1] * exp(-xdata[i] * p[2]))
             v1 = v[1]
             v2 = v[2]
-            dir_deriv[i] = h11*v1^2+2*h12*v1*v2 + h22*v2^2
+            # manually compute v'Hv. This whole process might seem cumbersome, but 
+            # allocating temporary matrices quickly becomes REALLY expensive and might even 
+            # render the use of geodesic acceleration terribly inefficient  
+            dir_deriv[i] = h11*v1^2 + 2*h12*v1*v2 + h22*v2^2
+
         end
     end 
 
 
     curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=1); #warmup
-    curve_fit(model, jacobian_model, Avv, xdata, ydata, p0; maxIter=1);
+    curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=1, avv! = Avv!);
 
     println("--------------\nPerformance of curve_fit vs geo")
 
@@ -45,10 +50,32 @@ let
 
 
     println("\t Geodesic")
-    fit_geo = @time curve_fit(model, jacobian_model, Avv, xdata, ydata, p0; maxIter=100)
+    fit_geo = @time curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=100, avv! = Avv!)
     @test fit_geo.converged
 
     @test maximum(fit.param-fit_geo.param) < 1e-8
+
+
+    #with noise
+    yvars = 1e-6*rand(length(xdata))
+    ydata = model(xdata, [1.0, 2.0]) + sqrt.(yvars) .* randn(length(xdata))
+
+    #warm up
+    curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, p0; maxIter=1)
+    curve_fit(model, jacobian_model, xdata, ydata,  1 ./ yvars, p0; maxIter=1, avv! = Avv!)
+
+    println("--------------\nPerformance of curve_fit vs geo with weights")
+
+    println("\t Non-inplace")
+    fit_wt = @time curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, p0; maxIter=100)
+    @test fit_wt.converged
+
+
+    println("\t Geodesic")
+    fit_geo_wt = @time curve_fit(model, jacobian_model, xdata, ydata,  1 ./ yvars, p0; maxIter=100, avv! = Avv!)
+    @test fit_geo_wt.converged
+
+    @test maximum(fit_wt.param-fit_geo_wt.param) < 1e-8
 
 
 end

--- a/test/geodesic.jl
+++ b/test/geodesic.jl
@@ -1,27 +1,38 @@
 let
     # fitting noisy data to an exponential model
     model(x, p) = @. p[1] * exp(-x * p[2])
-
+    #model(x,p) = [p[1],100*(p[2]-p[1]^2)]
     # some example data
     Random.seed!(12345)
     xdata = range(0, stop=10, length=50000)
     ydata = model(xdata, [1.0, 2.0]) + 0.01*randn(length(xdata))
-    p0 = [20., 20.]
-
+    p0 = [.5, .5]
+ #   xdata = [0, 0] #useless anyway
+ #   ydata = [0, 0]
+ #   p0 = [-1., 1.]
+#(/ x(1), 100*(x(2) - x(1)**2) /)
     # if your model is differentiable, it can be faster and/or more accurate
     # to supply your own jacobian instead of using the finite difference
+   #= function jacobian_model(x,p)
+        [1. 0.; -200 *p[1] 100]
+    end=#
     function jacobian_model(x,p)
         J = Array{Float64}(undef, length(x), length(p))
         @. J[:,1] = exp(-x*p[2])     #dmodel/dp[1]
         @. @views J[:,2] = -x*p[1]*J[:,1] 
         J
-    end
+end
 
     # a couple notes on the Avv function:
     # - the basic idea is to see the model output as simply a collection of functions: f1...fm
     # - then Avv return an array of size m, where each elements corresponds to
     # v'H(p)v, with H an n*n Hessian matrix of the m-th function, with n the size of p
-    function Avv!(p,v,dir_deriv)
+   #= function Avv!(p,v,dir_deriv)
+        dir_deriv[1] = 0
+        dir_deriv[2] = -200*v[1]^2
+    end =#
+
+function Avv!(p,v,dir_deriv)
         for i=1:length(xdata)
             #compute all the elements of the H matrix
             h11 = 0
@@ -36,24 +47,28 @@ let
             dir_deriv[i] = h11*v1^2 + 2*h12*v1*v2 + h22*v2^2
 
         end
-    end 
+end 
 
 
     curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=1); #warmup
-    curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=1, avv! = Avv!);
+    curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=1, avv! = Avv!,lambda=0, min_step_quality = 0); #lambda = 0 to match Mark's code
 
     println("--------------\nPerformance of curve_fit vs geo")
 
     println("\t Non-inplace")
-    fit = @time curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=100)
+    fit = @time curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=1000)
     @test fit.converged
 
 
+
     println("\t Geodesic")
-    fit_geo = @time curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=100, avv! = Avv!)
+    fit_geo = @time curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=10, avv! = Avv!,lambda=0, min_step_quality = 0)
     @test fit_geo.converged
 
-    @test maximum(fit.param-fit_geo.param) < 1e-8
+    println( maximum(fit.param-fit_geo.param))
+
+    println("fit params:",fit.param)
+    println("fit params geo:",fit_geo.param)
 
 
     #with noise
@@ -62,7 +77,7 @@ let
 
     #warm up
     curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, p0; maxIter=1)
-    curve_fit(model, jacobian_model, xdata, ydata,  1 ./ yvars, p0; maxIter=1, avv! = Avv!)
+    curve_fit(model, jacobian_model, xdata, ydata,  1 ./ yvars, p0; maxIter=1, avv! = Avv!,lambda=0, min_step_quality = 0)
 
     println("--------------\nPerformance of curve_fit vs geo with weights")
 
@@ -72,10 +87,10 @@ let
 
 
     println("\t Geodesic")
-    fit_geo_wt = @time curve_fit(model, jacobian_model, xdata, ydata,  1 ./ yvars, p0; maxIter=100, avv! = Avv!)
+    fit_geo_wt = @time curve_fit(model, jacobian_model, xdata, ydata,  1 ./ yvars, p0; maxIter=100, avv! = Avv!,lambda=0, min_step_quality = 0)
     @test fit_geo_wt.converged
 
-    @test maximum(fit_wt.param-fit_geo_wt.param) < 1e-8
+    println(maximum(fit_wt.param-fit_geo_wt.param))
 
 
 end

--- a/test/geodesic.jl
+++ b/test/geodesic.jl
@@ -1,38 +1,38 @@
+using BenchmarkTools
+
 let
+    
+
     # fitting noisy data to an exponential model
     model(x, p) = @. p[1] * exp(-x * p[2])
     #model(x,p) = [p[1],100*(p[2]-p[1]^2)]
     # some example data
     Random.seed!(12345)
-    xdata = range(0, stop=10, length=50000)
+    xdata = range(0, stop=10, length=50_000)
     ydata = model(xdata, [1.0, 2.0]) + 0.01*randn(length(xdata))
     p0 = [.5, .5]
- #   xdata = [0, 0] #useless anyway
- #   ydata = [0, 0]
- #   p0 = [-1., 1.]
-#(/ x(1), 100*(x(2) - x(1)**2) /)
-    # if your model is differentiable, it can be faster and/or more accurate
-    # to supply your own jacobian instead of using the finite difference
-   #= function jacobian_model(x,p)
-        [1. 0.; -200 *p[1] 100]
-    end=#
+
     function jacobian_model(x,p)
         J = Array{Float64}(undef, length(x), length(p))
         @. J[:,1] = exp(-x*p[2])     #dmodel/dp[1]
         @. @views J[:,2] = -x*p[1]*J[:,1] 
         J
-end
+    end
+
+    #Generating the "automatic" avv
+    model_inplace(out, p) =  @. out = p[1] * exp(-xdata * p[2])
+
+    hessians = Array{Float64}(undef, length(xdata)*length(p0), length(p0))
+    h! = make_hessian(model_inplace, xdata, p0)
+    auto_avv! = Avv(h!, length(p0), length(xdata))
+    
+    
 
     # a couple notes on the Avv function:
     # - the basic idea is to see the model output as simply a collection of functions: f1...fm
     # - then Avv return an array of size m, where each elements corresponds to
     # v'H(p)v, with H an n*n Hessian matrix of the m-th function, with n the size of p
-   #= function Avv!(p,v,dir_deriv)
-        dir_deriv[1] = 0
-        dir_deriv[2] = -200*v[1]^2
-    end =#
-
-function Avv!(p,v,dir_deriv)
+    function manual_avv!(p,v,dir_deriv)
         v1 = v[1]
         v2 = v[2]
         for i=1:length(xdata)
@@ -48,11 +48,12 @@ function Avv!(p,v,dir_deriv)
             dir_deriv[i] = h11*v1^2 + 2*h12*v1*v2 + h22*v2^2
 
         end
-end 
+    end 
 
 
     curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=1); #warmup
-    curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=1, avv! = Avv!,lambda=0, min_step_quality = 0); #lambda = 0 to match Mark's code
+    curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=1, avv! = manual_avv!,lambda=0, min_step_quality = 0); #lambda = 0 to match Mark's code
+    curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=10, avv! = auto_avv!,lambda=0, min_step_quality = 0)
 
     println("--------------\nPerformance of curve_fit vs geo")
 
@@ -61,14 +62,21 @@ end
     @test fit.converged
 
 
-
     println("\t Geodesic")
-    fit_geo = @time curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=10, avv! = Avv!,lambda=0, min_step_quality = 0)
+    fit_geo = @time curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=10, avv! = manual_avv!,lambda=0, min_step_quality = 0)
     @test fit_geo.converged
 
-    @test maximum(abs.(fit.param-fit_geo.param)) < 1e-6
+    
+    println("\t Geodesic - auto avv!")
+    fit_geo_auto = @time curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=10, avv! = auto_avv!,lambda=0, min_step_quality = 0)
+    @test fit_geo_auto.converged
+
 
     @test maximum(abs.(fit.param-[1.0, 2.0])) < 1e-1
+    @test maximum(abs.(fit.param-fit_geo.param)) < 1e-6
+    @test maximum(abs.(fit.param-fit_geo_auto.param)) < 1e-6
+
+
 
     #with noise
     yvars = 1e-6*rand(length(xdata))
@@ -76,7 +84,8 @@ end
 
     #warm up
     curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, p0; maxIter=1)
-    curve_fit(model, jacobian_model, xdata, ydata,  1 ./ yvars, p0; maxIter=1, avv! = Avv!,lambda=0, min_step_quality = 0)
+    curve_fit(model, jacobian_model, xdata, ydata,  1 ./ yvars, p0; maxIter=1, avv! = manual_avv!,lambda=0, min_step_quality = 0)
+    curve_fit(model, jacobian_model, xdata, ydata,  1 ./ yvars, p0; maxIter=1, avv! = auto_avv!,lambda=0, min_step_quality = 0)
 
     println("--------------\nPerformance of curve_fit vs geo with weights")
 
@@ -86,12 +95,18 @@ end
 
 
     println("\t Geodesic")
-    fit_geo_wt = @time curve_fit(model, jacobian_model, xdata, ydata,  1 ./ yvars, p0; maxIter=100, avv! = Avv!,lambda=0, min_step_quality = 0)
+    fit_geo_wt = @time curve_fit(model, jacobian_model, xdata, ydata,  1 ./ yvars, p0; maxIter=100, avv! = manual_avv!,lambda=0, min_step_quality = 0)
     @test fit_geo_wt.converged
 
-    @test maximum(abs.(fit_wt.param-fit_geo_wt.param)) < 1e-6
+
+    println("\t Geodesic - auto avv!")
+    fit_geo_auto_wt = @time curve_fit(model, jacobian_model, xdata, ydata,  1 ./ yvars, p0; maxIter=100, avv! = auto_avv!,lambda=0, min_step_quality = 0)
+    @test fit_geo_auto_wt.converged
+
 
     @test maximum(abs.(fit_wt.param-[1.0, 2.0])) < 1e-1
+    @test maximum(abs.(fit_wt.param-fit_geo_wt.param)) < 1e-6
+    @test maximum(abs.(fit_wt.param-fit_geo_auto_wt.param)) < 1e-6
 
 end
 

--- a/test/geodesic.jl
+++ b/test/geodesic.jl
@@ -33,14 +33,15 @@ end
     end =#
 
 function Avv!(p,v,dir_deriv)
+        v1 = v[1]
+        v2 = v[2]
         for i=1:length(xdata)
             #compute all the elements of the H matrix
             h11 = 0
             h12 = (-xdata[i] * exp(-xdata[i] * p[2]))
             #h21 = h12
             h22 = (xdata[i]^2 * p[1] * exp(-xdata[i] * p[2]))
-            v1 = v[1]
-            v2 = v[2]
+
             # manually compute v'Hv. This whole process might seem cumbersome, but 
             # allocating temporary matrices quickly becomes REALLY expensive and might even 
             # render the use of geodesic acceleration terribly inefficient  
@@ -65,11 +66,9 @@ end
     fit_geo = @time curve_fit(model, jacobian_model, xdata, ydata, p0; maxIter=10, avv! = Avv!,lambda=0, min_step_quality = 0)
     @test fit_geo.converged
 
-    println( maximum(fit.param-fit_geo.param))
+    @test maximum(abs.(fit.param-fit_geo.param)) < 1e-6
 
-    println("fit params:",fit.param)
-    println("fit params geo:",fit_geo.param)
-
+    @test maximum(abs.(fit.param-[1.0, 2.0])) < 1e-1
 
     #with noise
     yvars = 1e-6*rand(length(xdata))
@@ -90,8 +89,9 @@ end
     fit_geo_wt = @time curve_fit(model, jacobian_model, xdata, ydata,  1 ./ yvars, p0; maxIter=100, avv! = Avv!,lambda=0, min_step_quality = 0)
     @test fit_geo_wt.converged
 
-    println(maximum(fit_wt.param-fit_geo_wt.param))
+    @test maximum(abs.(fit_wt.param-fit_geo_wt.param)) < 1e-6
 
+    @test maximum(abs.(fit_wt.param-[1.0, 2.0])) < 1e-1
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using LsqFit, Test, LinearAlgebra, Random
 using OptimBase, Calculus
 import NLSolversBase: OnceDifferentiable
 
-my_tests = [ "curve_fit.jl", "geodesic.jl"]
+my_tests = [ "curve_fit.jl", "levenberg_marquardt.jl", "geodesic.jl"]
 
 println("Running tests:")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,11 @@
 #
 # Correctness Tests
 #
-
 using LsqFit, Test, LinearAlgebra, Random
 using OptimBase, Calculus
 import NLSolversBase: OnceDifferentiable
 
-my_tests = [ "curve_fit.jl", "levenberg_marquardt.jl"]
+my_tests = [ "curve_fit.jl", "geodesic.jl"]
 
 println("Running tests:")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 #
 # Correctness Tests
 #
+
 using LsqFit, Test, LinearAlgebra, Random
 using OptimBase, Calculus
 import NLSolversBase: OnceDifferentiable


### PR DESCRIPTION
Implementing what was proposed in issue https://github.com/JuliaNLSolvers/LsqFit.jl/issues/88 -- ~~only for the (non inplace) jacobian, without weights, case so far.~~

In the example set up in test/geodesic.jl, it decreases the number of iterations from 25 to 11. 

The main problems are: 
- ~~the implementation is really ugly. I had to entirely copy the `lm` function for now. I think that a proper implementation will likely require that we have `GeodesicSettings` type or something along these lines~~

- ~~The performance is fairly poor. Due to the extra step needed to 1) first create a potentially large array of `n*n`Hessian 2) perform some matrix multiplication on each of these, both the memory consumption, and the run time are larger *in the example considered*~~.Performance is decent, I'll poke around and see what be can improved
~~I think it might be interesting to make the user input `Avv` directly, and have `getvHv`(should probably rename it just `vHv`) as a helper function, if someone doesn't want to go through writing Avv themselves~~ done

- ~~more of a TODO than a problem, but obviously, need to expand it to other cases~~

- ~~also just realized I didn't comment my code~~

- ~~TODO: entry in readme~~