### PR TITLE
Implement suggested start dampening parameter as per IMM-REP-1999-05,…

### DIFF
--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -33,15 +33,18 @@ Comp & Applied Math).
 # it would probably be very inefficient performace-wise for most cases, but it wouldn't hurt to have it somewhere
 function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T};
     x_tol::Real = 1e-8, g_tol::Real = 1e-12, maxIter::Integer = 1000,
-    lambda = T(10), tau=1/T(10^6), lambda_increase::Real = 10.0, lambda_decrease::Real = 0.1,
+    lambda = T(10), tau=T(Inf), lambda_increase::Real = 10.0, lambda_decrease::Real = 0.1,
     min_step_quality::Real = 1e-3, good_step_quality::Real = 0.75,
     show_trace::Bool = false, lower::Vector{T} = Array{T}(undef, 0), upper::Vector{T} = Array{T}(undef, 0), avv!::Union{Function,Nothing,Avv} = nothing
     ) where T
 
     # First evaluation
     value_jacobian!!(df, initial_x)
+    if isfinite(tau)
+        lambda_heuristic = tau*maximum(jacobian(df)'*jacobian(df))
+        lambda = min(lambda, lambda_heuristic)
+    end
 
-    lambda = min(lambda, tau*maximum(jacobian(df)'*jacobian(df)))
 
     # check parameters
     ((isempty(lower) || length(lower)==length(initial_x)) && (isempty(upper) || length(upper)==length(initial_x))) ||

--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -19,8 +19,8 @@ Comp & Applied Math).
 * `maxIter::Integer=1000`: maximum number of iterations
 * `min_step_quality=1e-3`: for steps below this quality, the trust region is shrinked
 * `good_step_quality=0.75`: for steps above this quality, the trust region is expanded
-* `lambda::Real=10`: upper limit of (inverse of) initial trust region radius according to min(lambda, tau*maximum(J'*J))
-* `tau`=1e-6
+* `lambda::Real=10`: (inverse of) initial trust region radius
+* `tau=Inf`: set initial trust region radius using the heuristic : tau*maximum(jacobian(df)'*jacobian(df))
 * `lambda_increase=10.0`: `lambda` is multiplied by this factor after step below min quality
 * `lambda_decrease=0.1`: `lambda` is multiplied by this factor after good quality steps
 * `show_trace::Bool=false`: print a status summary on each iteration if true
@@ -40,9 +40,9 @@ function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T
 
     # First evaluation
     value_jacobian!!(df, initial_x)
+    
     if isfinite(tau)
-        lambda_heuristic = tau*maximum(jacobian(df)'*jacobian(df))
-        lambda = min(lambda, lambda_heuristic)
+        lambda = tau*maximum(jacobian(df)'*jacobian(df))
     end
 
 

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -49,4 +49,7 @@ let
     println("norm(fit.param - [1.0, 2.0]) < 0.05 ? ", norm(fit.param - [1.0, 2.0]))
     @assert norm(fit.param - [1.0, 2.0]) < 0.05
     @test fit.converged
+
+
+    curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, [0.5, 0.5]; tau=0.0001)
 end


### PR DESCRIPTION
… but with a user supplied upper limit.

Fixes #34 though I need to actually look at some runs to make a judgement call here.

I've done it in a way where the original lambda default is preserved (for now), and the heuristic is used if the `tau` keyword is set.

We should benchmark in the future, so see if we should update the default.