### PR TITLE
Specify that the model parameters must be Floats

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -7,7 +7,7 @@ First, import the package.
 julia> using LsqFit
 ```
 
-Define a two-parameter exponential decay model, where ``t`` is a one-element independent variable, ``p_1`` and ``p_2`` are parameters.
+Define a two-parameter exponential decay model, where ``t`` is a one-element independent variable, ``p_1`` and ``p_2`` are __float__ parameters.
 
 The model function is:
 


### PR DESCRIPTION
I think this should be specified. I wanted to use the curve_fit function and I followed the tutorial but in my use case I was getting an Inexact error Int64(Float64). It took me about an hour to figure out this simple mistake. Model parameters must be floats. Is it best to specify it in order to make this easier to use for new users and avoid frustration.