### PR TITLE
Allow AbstractVector{T} for lower and upper instead of Vector{T}

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ There's nothing inherently different if there are more than one variable enterin
 ```
 Evaluating the Jacobian and using automatic differentiation
 -------------------------
+The default is to calculate the Jacobian using a central finite differences scheme if no Jacobian function is provided. The default is to use central differences because it can be more accurate than forward finite differences, but at the expense of computational cost. It is possible to switch to forward finite differences, like MINPACK uses for example, by specifying
 ```julia
 fit = curve_fit(model, xdata, ydata, p0; autodiff=:finiteforward)
 ```

--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -28,19 +28,19 @@ Comp & Applied Math).
 """
 
 # I think a smarter way to do this *might* be to create a type similar to `OnceDifferentiable`
-# and the like. This way we could not only merge the two functions, but also have a convinient
+# and the like. This way we could not only merge the two functions, but also have a convenient
 # way to provide an autodiff-made acceleration when someone doesn't provide an `avv`.
 # it would probably be very inefficient performace-wise for most cases, but it wouldn't hurt to have it somewhere
 function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T};
     x_tol::Real = 1e-8, g_tol::Real = 1e-12, maxIter::Integer = 1000,
     lambda = T(10), tau=T(Inf), lambda_increase::Real = 10.0, lambda_decrease::Real = 0.1,
     min_step_quality::Real = 1e-3, good_step_quality::Real = 0.75,
-    show_trace::Bool = false, lower::Vector{T} = Array{T}(undef, 0), upper::Vector{T} = Array{T}(undef, 0), avv!::Union{Function,Nothing,Avv} = nothing
+    show_trace::Bool = false, lower::AbstractVector{T} = Array{T}(undef, 0), upper::AbstractVector{T} = Array{T}(undef, 0), avv!::Union{Function,Nothing,Avv} = nothing
     ) where T
 
     # First evaluation
     value_jacobian!!(df, initial_x)
-    
+
     if isfinite(tau)
         lambda = tau*maximum(jacobian(df)'*jacobian(df))
     end


### PR DESCRIPTION
For my particular use case, I'd like to pass box constraints for `lower` and `upper` of type `SVector` to the Optimizer as this is what comes naturally out of my pipeline.

I also made some very minor cosmetic changes to README.md