### PR TITLE
Add plot recipe for fit result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 benchmarks/graphs/*
 *~
 *.kate-swp
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLSolversBase = "d41bc354-129a-5804-8e4c-c37616107c6c"
 OptimBase = "87e2bd06-a317-5318-96d9-3ecbac512eee"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
@@ -16,6 +17,7 @@ Distributions = "0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24"
 ForwardDiff = "0.10"
 NLSolversBase = "7.5"
 OptimBase = "2.0"
+RecipesBase = "1"
 StatsBase = "0.32, 0.33"
 julia = "1.1"
 

--- a/src/LsqFit.jl
+++ b/src/LsqFit.jl
@@ -15,6 +15,7 @@ module LsqFit
     using OptimBase
     using LinearAlgebra
     using ForwardDiff
+    using RecipesBase
     import NLSolversBase: value, jacobian
     import StatsBase
     import StatsBase: coef, dof, nobs, rss, stderror, weights, residuals
@@ -24,5 +25,6 @@ module LsqFit
     include("geodesic.jl")
     include("levenberg_marquardt.jl")
     include("curve_fit.jl")
+    include("plot.jl")
 
 end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,0 +1,75 @@
+@recipe function f(model::Function, fit::LsqFitResult; significance=0.05, purpose=:neither)
+    @series begin
+        seriestype --> :line
+        label --> "Fit"
+        x->model(x, fit.param)
+    end
+    if purpose in (:confidence, :both)
+        @series begin
+            seriestype := :line
+            seriescolor := :black
+            linestyle := :dash
+            label := ["Confidence interval" nothing]
+
+            [
+             x -> model(x, fit.param) - margin_error(model, x, fit, significance),
+             x -> model(x, fit.param) + margin_error(model, x, fit, significance)
+            ]
+        end
+    end
+    if purpose in (:prediction, :both)
+        @series begin
+            seriestype := :line
+            seriescolor := :black
+            linestyle := :dot
+            label := ["Prediction interval" nothing]
+
+            [
+             x -> model(x, fit.param) - margin_error(model, x, fit, significance; purpose=:prediction)
+             x -> model(x, fit.param) + margin_error(model, x, fit, significance; purpose=:prediction)
+            ]
+        end
+    end
+end
+
+
+"""
+```julia
+_band(direction, model, x, p_conf)
+```
+
+Evaluates `model(x, p)` for each combination `p` in `pconf` (e.g. `[low, low, low]`, `[low, low, high]`...),
+and returns the `direction`st return value.
+
+# Example
+```julia
+_band(minimum, model, x, [(0.0, 1.0), (2.0, 3.0)]) == minimum([model(x, [0.0, 2.0]), model(x, [0.0, 3.0]), model(x, [1.0, 2.0]), model(x, [1.0, 3.0])])
+```
+"""
+function _band(direction, model, x, p_conf)
+    l = length(p_conf)
+    return direction(begin
+                         i = digits(k; base=2, pad=l) .+ 1
+                         p = getindex.(p_conf, i)
+                         y = model(x, p)
+                     end
+                     for k in 0:2^l-1
+                    )
+end
+
+"""
+```julia
+margin_error(model, x, fit, significance; purpose)
+```
+Find the width at `x` of the confidence or prediction interval.
+"""
+function margin_error(model::Function, x, fit::LsqFitResult, alpha=0.05; purpose=:confidence)
+    g = p -> ForwardDiff.gradient(p -> model(x, p), fit.param)
+    c = g(fit.param)' * estimate_covar(fit) * g(fit.param)
+    if purpose === :prediction
+        c = c + 1
+    end
+    dist = TDist(dof(fit))
+    critical_values = quantile(dist, 1 - alpha/2)
+    return sqrt(c*rss(fit)/dof(fit))*critical_values
+end


### PR DESCRIPTION
(might close #139)

Implements a plot recipe for fit results. Uses the delta method (as described [here](https://stats.stackexchange.com/questions/85448/shape-of-confidence-and-prediction-intervals-for-nonlinear-regression)) to form confidence and prediction bands.

My statistics is shaky, it's been a couple of years, so this might be a terrible way to do this. Which is why I'm asking for input before I go through the trouble of writing docs and tests.

Is this desirable?

```julia
plot(tdata, ydata; seriestype=:scatter, label="Samples")
plot!(model, fit; significance=0.05, purpose=:both)
```
:

![plot](https://user-images.githubusercontent.com/6677110/113938625-26e41780-97fb-11eb-9548-14a7503e43a3.png)