### PR TITLE
ensure monotonous decay

### DIFF
--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -175,7 +175,7 @@ function levenberg_marquardt(df::OnceDifferentiable, initial_x::AbstractVector{T
 
         # step quality = residual change / predicted residual change
         rho = (trial_residual - residual) / (predicted_residual - residual)
-        if rho > min_step_quality
+        if trial_residual < residual && rho > min_step_quality
             # apply the step to x - n_buffer is ready to be used by the delta_x
             # calculations after this step.
             x .= n_buffer


### PR DESCRIPTION
Hi everyone!
For my fits the residuum jumps up by two orders of magnitude some point, while lamdba is small. Not sure if this PR is an appropriate counter-action, but a) it works, and b) I am assuming that the algorithm should not step when it increases the residual, or should it? Maybe this fixes also issue https://github.com/JuliaNLSolvers/LsqFit.jl/issues/164 . 

Let me know what you think!
Best,
Jakob