### PR TITLE
Added check function for weighted data

### DIFF
--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -15,11 +15,11 @@ StatsBase.weights(lfr::LsqFitResult) = lfr.wt
 StatsBase.residuals(lfr::LsqFitResult) = lfr.resid
 mse(lfr::LsqFitResult) = rss(lfr)/dof(lfr)
 
-function check_data_health(xdata, ydata)
-    if any(ismissing, xdata) || any(ismissing, ydata)
+function check_data_health(xdata, ydata, wt = [])
+    if any(ismissing, xdata) || any(ismissing, ydata) || any(ismissing, wt)
         error("Data contains `missing` values and a fit cannot be performed")
     end
-    if any(isinf, xdata) || any(isinf, ydata) || any(isnan, xdata) || any(isnan, ydata)
+    if any(isinf, xdata) || any(isinf, ydata) || any(isinf, wt) || any(isnan, xdata) || any(isnan, ydata) || any(isnan, wt)
         error("Data contains `Inf` or `NaN` values and a fit cannot be performed")
     end
 end
@@ -137,7 +137,7 @@ function curve_fit(model, jacobian_model,
 end
 
 function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray, p0::AbstractArray; inplace = false, kwargs...)
-    check_data_health(xdata, ydata)
+    check_data_health(xdata, ydata, wt)
     # construct a weighted cost function, with a vector weight for each ydata
     # for example, this might be wt = 1/sigma where sigma is some error term
     u = sqrt.(wt) # to be consistant with the matrix form
@@ -153,7 +153,7 @@ end
 
 function curve_fit(model, jacobian_model,
             xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray, p0::AbstractArray; inplace = false, kwargs...)
-    check_data_health(xdata, ydata)
+    check_data_health(xdata, ydata, wt)
     u = sqrt.(wt) # to be consistant with the matrix form
 
     if inplace
@@ -168,7 +168,7 @@ function curve_fit(model, jacobian_model,
 end
 
 function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, wt::AbstractMatrix, p0::AbstractArray; kwargs...)
-    check_data_health(xdata, ydata)
+    check_data_health(xdata, ydata, wt)
 
     # as before, construct a weighted cost function with where this
     # method uses a matrix weight.
@@ -185,7 +185,7 @@ end
 
 function curve_fit(model, jacobian_model,
             xdata::AbstractArray, ydata::AbstractArray, wt::AbstractMatrix, p0::AbstractArray; kwargs...)
-    check_data_health(xdata, ydata)
+    check_data_health(xdata, ydata, wt)
 
     u = cholesky(wt).U
 

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -17,7 +17,7 @@ mse(lfr::LsqFitResult) = rss(lfr)/dof(lfr)
 
 function check_data_health(xdata, ydata, wt = [])
     if any(ismissing, xdata)
-        error("The independent variable ()`x`) contains `missing` values and a fit cannot be performed")
+        error("The independent variable (`x`) contains `missing` values and a fit cannot be performed")
     end
     if any(ismissing, ydata)
         error("The dependent variable (`y`) contains `missing` values and a fit cannot be performed")
@@ -25,13 +25,13 @@ function check_data_health(xdata, ydata, wt = [])
     if any(ismissing, wt)
         error("Weight data contains `missing` values and a fit cannot be performed")
     end
-    if any(isfinite, xdata)
+    if any(!isfinite, xdata)
         error("The independent variable (`x`) contains non-finite (e.g. `Inf`, `NaN`) values and a fit cannot be performed")
     end
-    if any(isfinite, ydata)
+    if any(!isfinite, ydata)
         error("The dependent variable (`y`) contains non-finite (e.g. `Inf`, `NaN`) values and a fit cannot be performed")
     end
-    if any(isfinite, wt)
+    if any(!isfinite, wt)
         error("Weight contains non-finite (e.g. `Inf`, `NaN`) values and a fit cannot be performed")
     end
         

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -16,12 +16,25 @@ StatsBase.residuals(lfr::LsqFitResult) = lfr.resid
 mse(lfr::LsqFitResult) = rss(lfr)/dof(lfr)
 
 function check_data_health(xdata, ydata, wt = [])
-    if any(ismissing, xdata) || any(ismissing, ydata) || any(ismissing, wt)
-        error("Data contains `missing` values and a fit cannot be performed")
+    if any(ismissing, xdata)
+        error("The independent variable ()`x`) contains `missing` values and a fit cannot be performed")
     end
-    if any(isinf, xdata) || any(isinf, ydata) || any(isinf, wt) || any(isnan, xdata) || any(isnan, ydata) || any(isnan, wt)
-        error("Data contains `Inf` or `NaN` values and a fit cannot be performed")
+    if any(ismissing, ydata)
+        error("The dependent variable (`y`) contains `missing` values and a fit cannot be performed")
     end
+    if any(ismissing, wt)
+        error("Weight data contains `missing` values and a fit cannot be performed")
+    end
+    if any(isfinite, xdata)
+        error("The independent variable (`x`) contains non-finite (e.g. `Inf`, `NaN`) values and a fit cannot be performed")
+    end
+    if any(isfinite, ydata)
+        error("The dependent variable (`y`) contains non-finite (e.g. `Inf`, `NaN`) values and a fit cannot be performed")
+    end
+    if any(isfinite, wt)
+        error("Weight contains non-finite (e.g. `Inf`, `NaN`) values and a fit cannot be performed")
+    end
+        
 end
 
 # provide a method for those who have their own Jacobian function

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -1,11 +1,11 @@
 let
     # before testing the model, check whether missing/null data is rejected
     tdata = [rand(1:10, 5)..., missing]
-    @test_throws ErrorException("Data contains `missing` values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
+    @test_throws ErrorException("The independent variable (`x`) contains `missing` values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
     tdata = [rand(1:10, 5)..., Inf]
-    @test_throws ErrorException("Data contains `Inf` or `NaN` values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
+    @test_throws ErrorException("The independent variable (`x`) contains non-finite (e.g. `Inf`, `NaN`) values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
     tdata = [rand(1:10, 5)..., NaN]
-    @test_throws ErrorException("Data contains `Inf` or `NaN` values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
+    @test_throws ErrorException("The independent variable (`x`) contains non-finite (e.g. `Inf`, `NaN`) values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
    
     # fitting noisy data to an exponential model
     # TODO: Change to `.-x` when 0.5 support is dropped

--- a/test/curve_fit_inplace.jl
+++ b/test/curve_fit_inplace.jl
@@ -125,21 +125,21 @@ let
     @test fit_wt.converged
 
     @testset "bad input" begin
-        xxdata = copy(xdata)
+        xxdata = copy(collect(xdata))
         yydata = copy(ydata)
-        WT = 1 ./ sqrt.(yvars)
+        WWT = 1 ./ sqrt.(yvars)
         x1 = xxdata[1]
         y1 = yydata[1]
-        wt1 = WT[1]
+        wt1 = WWT[1]
         for x in (x1, Inf, -Inf, NaN), y in (y1, Inf, -Inf, NaN), wt in (wt1, Inf, -Inf, NaN)
 
             xxdata[1] = x
             yydata[1] = y
             WWT[1] = wt
             if x == x1 && y == y1 && wt == wt1
-                @test_nowarn curve_fit(model, jacobian_model, xdata, ydata, WT, [0.5, 0.5]; maxIter=100)
+                @test_nowarn curve_fit(model, jacobian_model, xxdata, yydata, WWT, [0.5, 0.5]; maxIter=100)
             else
-                @test_throws ErrorException curve_fit(model, jacobian_model, xdata, ydata, WT, [0.5, 0.5]; maxIter=100)
+                @test_throws ErrorException curve_fit(model, jacobian_model, xxdata, yydata, WWT, [0.5, 0.5]; maxIter=100)
             end
         end
     end

--- a/test/curve_fit_inplace.jl
+++ b/test/curve_fit_inplace.jl
@@ -124,6 +124,26 @@ let
     fit_wt = @time curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, [0.5, 0.5]; maxIter=100)
     @test fit_wt.converged
 
+    @testset "bad input" begin
+        xxdata = copy(xdata)
+        yydata = copy(ydata)
+        WT = 1 ./ sqrt.(yvars)
+        x1 = xxdata[1]
+        y1 = yydata[1]
+        wt1 = WT[1]
+        for x in (x1, Inf, -Inf, NaN), y in (y1, Inf, -Inf, NaN), wt in (wt1, Inf, -Inf, NaN)
+
+            xxdata[1] = x
+            yydata[1] = y
+            WWT[1] = wt
+            if x == x1 && y == y1 && wt == wt1
+                @test_nowarn curve_fit(model, jacobian_model, xdata, ydata, WT, [0.5, 0.5]; maxIter=100)
+            else
+                @test_throws ErrorException curve_fit(model, jacobian_model, xdata, ydata, WT, [0.5, 0.5]; maxIter=100)
+            end
+        end
+    end
+
     println("\t Inplace with weights")
     fit_inplace_wt = @time curve_fit(model_inplace, xdata, ydata, 1 ./ yvars, [0.5, 0.5]; inplace = true, maxIter=100)
     @test fit_inplace_wt.converged


### PR DESCRIPTION
I ran into a small problem, that `curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0::AbstractArray; inplace = false, kwargs...) where T` tried to fit my function for a weight `1/0 = Inf`. 
So I thought it would be useful to also check weights for `NaN`, `Inf` or `Missing`-values if provided.