### PR TITLE
Changed standard_error to stderror

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -55,10 +55,10 @@ julia> cov = estimate_covar(fit)
  0.000174633  0.00258261
 ```
 
-`standard_error(fit)` returns the standard error of each parameter.
+`standard_errors(fit)` returns the standard error of each parameter.
 
 ```Julia
-julia> se = standard_error(fit)
+julia> se = standard_errors(fit)
 2-element Array{Float64,1}:
  0.0107956
  0.0508193

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -55,10 +55,10 @@ julia> cov = estimate_covar(fit)
  0.000174633  0.00258261
 ```
 
-`standard_errors(fit)` returns the standard error of each parameter.
+`stderror(fit)` returns the standard error of each parameter.
 
 ```Julia
-julia> se = standard_errors(fit)
+julia> se = stderror(fit)
 2-element Array{Float64,1}:
  0.0107956
  0.0508193

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -195,10 +195,10 @@ julia> cov = estimate_covar(fit)
  0.000174633  0.00258261
 ```
 
-The standard error is then the square root of each diagonal elements of the covariance matrix. `standard_error()` returns the standard error of each parameter:
+The standard error is then the square root of each diagonal elements of the covariance matrix. `standard_errors()` returns the standard error of each parameter:
 
 ```Julia
-julia> se = standard_error(fit)
+julia> se = standard_errors(fit)
 2-element Array{Float64,1}:
  0.0114802
  0.0520416

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -195,10 +195,10 @@ julia> cov = estimate_covar(fit)
  0.000174633  0.00258261
 ```
 
-The standard error is then the square root of each diagonal elements of the covariance matrix. `standard_errors()` returns the standard error of each parameter:
+The standard error is then the square root of each diagonal elements of the covariance matrix. `stderror()` returns the standard error of each parameter:
 
 ```Julia
-julia> se = standard_errors(fit)
+julia> se = stderror(fit)
 2-element Array{Float64,1}:
  0.0114802
  0.0520416

--- a/src/LsqFit.jl
+++ b/src/LsqFit.jl
@@ -1,7 +1,6 @@
 module LsqFit
 
     export curve_fit,
-           standard_error,
            margin_error,
            confidence_interval,
            estimate_covar,


### PR DESCRIPTION
Reason (after "using LsqFit"):
ERROR: UndefVarError: standard_error not defined

https://github.com/githubIsNotOpenSourceLOL/LsqFit.jl/blob/91b358f64e63bb0505e733b1fc73f2d4ea6861bc/src/curve_fit.jl#L254
This shows that standard_errors is deprecated, which is why I used stderror.

The change is already done in the README, but this PR changes it in the documentation :)

Can you maybe remove standard_error and standard_errors from auto_completion suggestions after "using LsqFit"?

Merging this would close this issue:
https://github.com/JuliaNLSolvers/LsqFit.jl/issues/155