### PR TITLE
Update curve_fit.jl

### DIFF
--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -15,35 +15,38 @@ StatsBase.weights(lfr::LsqFitResult) = lfr.wt
 StatsBase.residuals(lfr::LsqFitResult) = lfr.resid
 mse(lfr::LsqFitResult) = rss(lfr)/dof(lfr)
 
-function check_data_health(xdata, ydata)
+function check_data_health(xdata, ydata, p0::AbstractVector{<:Real})
     if any(ismissing, xdata) || any(ismissing, ydata)
         error("Data contains `missing` values and a fit cannot be performed")
     end
     if any(isinf, xdata) || any(isinf, ydata) || any(isnan, xdata) || any(isnan, ydata)
         error("Data contains `Inf` or `NaN` values and a fit cannot be performed")
     end
+
+    # Make sure p0 is a vector of floats
+    return float.(p0)
 end
 
 # provide a method for those who have their own Jacobian function
-function lmfit(f, g, p0::AbstractArray, wt::AbstractArray; kwargs...)
+function lmfit(f, g, p0::AbstractVector{<:Real}, wt::AbstractArray; kwargs...)
     r = f(p0)
     R = OnceDifferentiable(f, g, p0, copy(r); inplace=false)
     lmfit(R, p0, wt; kwargs...)
 end
 
 #for inplace f and inplace g
-function lmfit(f!, g!, p0::AbstractArray, wt::AbstractArray, r::AbstractArray; kwargs...)
+function lmfit(f!, g!, p0::AbstractVector{<:Real}, wt::AbstractArray, r::AbstractArray; kwargs...)
     R = OnceDifferentiable(f!, g!, p0, copy(r); inplace = true)
     lmfit(R, p0, wt; kwargs...)
 end
 
 #for inplace f only
-function lmfit(f, p0::AbstractArray, wt::AbstractArray, r::AbstractArray; autodiff = :finite, kwargs...)
+function lmfit(f, p0::AbstractVector{<:Real}, wt::AbstractArray, r::AbstractArray; autodiff = :finite, kwargs...)
     R = OnceDifferentiable(f, p0, copy(r); inplace = true, autodiff = autodiff)
     lmfit(R, p0, wt; kwargs...)
 end
 
-function lmfit(f, p0::AbstractArray, wt::AbstractArray; autodiff = :finite, kwargs...)
+function lmfit(f, p0::AbstractVector{<:Real}, wt::AbstractArray; autodiff = :finite, kwargs...)
     # this is a convenience function for the curve_fit() methods
     # which assume f(p) is the cost functionj i.e. the residual of a
     # model where
@@ -64,7 +67,7 @@ function lmfit(f, p0::AbstractArray, wt::AbstractArray; autodiff = :finite, kwar
     lmfit(R, p0, wt; kwargs...)
 end
 
-function lmfit(R::OnceDifferentiable, p0::AbstractArray, wt::AbstractArray; autodiff = :finite, kwargs...)
+function lmfit(R::OnceDifferentiable, p0::AbstractVector{<:Real}, wt::AbstractArray; autodiff = :finite, kwargs...)
     results = levenberg_marquardt(R, p0; kwargs...)
     p = minimizer(results)
     return LsqFitResult(p, value!(R, p), jacobian!(R, p), converged(results), wt)
@@ -105,8 +108,8 @@ fit = curve_fit(model, xdata, ydata, p0)
 """
 function curve_fit end
 
-function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, p0::AbstractArray; inplace = false, kwargs...)
-    check_data_health(xdata, ydata)
+function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, p0::AbstractVector{<:Real}; inplace = false, kwargs...)
+    p0 = check_data_health(xdata, ydata, p0)
     # construct the cost function
     T = eltype(ydata)
 
@@ -120,8 +123,8 @@ function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, p0::Abstra
 end
 
 function curve_fit(model, jacobian_model,
-            xdata::AbstractArray, ydata::AbstractArray, p0::AbstractArray; inplace = false, kwargs...)
-    check_data_health(xdata, ydata)
+            xdata::AbstractArray, ydata::AbstractArray, p0::AbstractVector{<:Real}; inplace = false, kwargs...)
+    p0 = check_data_health(xdata, ydata, p0)
 
     T = eltype(ydata)
 
@@ -136,8 +139,8 @@ function curve_fit(model, jacobian_model,
     end
 end
 
-function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0::AbstractArray; inplace = false, kwargs...) where T
-    check_data_health(xdata, ydata)
+function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0::AbstractVector{<:Real}; inplace = false, kwargs...) where T
+    p0 = check_data_health(xdata, ydata, p0)
     # construct a weighted cost function, with a vector weight for each ydata
     # for example, this might be wt = 1/sigma where sigma is some error term
     u = sqrt.(wt) # to be consistant with the matrix form
@@ -152,8 +155,8 @@ function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, wt::Abstra
 end
 
 function curve_fit(model, jacobian_model,
-            xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0; inplace = false, kwargs...) where T
-    check_data_health(xdata, ydata)
+            xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0::AbstractVector{<:Real}; inplace = false, kwargs...) where T
+    p0 = check_data_health(xdata, ydata, p0)
     u = sqrt.(wt) # to be consistant with the matrix form
 
     if inplace
@@ -167,8 +170,8 @@ function curve_fit(model, jacobian_model,
     end
 end
 
-function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T,2}, p0; kwargs...) where T
-    check_data_health(xdata, ydata)
+function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T,2}, p0::AbstractVector{<:Real}; kwargs...) where T
+    p0 = check_data_health(xdata, ydata, p0)
 
     # as before, construct a weighted cost function with where this
     # method uses a matrix weight.
@@ -184,8 +187,8 @@ function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, wt::Abstra
 end
 
 function curve_fit(model, jacobian_model,
-            xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T,2}, p0; kwargs...) where T
-    check_data_health(xdata, ydata)
+            xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T,2}, p0::AbstractVector{<:Real}; kwargs...) where T
+    p0 = check_data_health(xdata, ydata, p0)
 
     u = cholesky(wt).U
 


### PR DESCRIPTION
An approach to solve the problem here:
https://github.com/JuliaNLSolvers/LsqFit.jl/pull/154

It would be easier and cleaner to remove the modification of check_data_health and modify
p0::AbstractVector{<:Real}
to
**p0::AbstractVector{<:AbstractFloat}**

But that could be restricting for users. You have the freedom to decide ;)

levenberg_marquardt takes a Vector, which is why I have chainged p0::AbstractArray to AbstractVector. {<:Real} is to make sure that we have at least a real number (which could be an integer). Or **does levenberg_marquardt also work for complex numbers?** In that case, "Real" has to be changed to "Number" and float() won't work anymore.

I guess, one also can use float() instead of float.() in this case. *Is there a difference?* Because float has a method for AbstractArray implemented anyway.