### PR TITLE
Fix typo in `curve_fit` docstring

### DIFF
--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -81,7 +81,7 @@ The return object is a composite type (`LsqFitResult`), with some interesting va
 * `fit.resid` : residuals = vector of residuals
 * `fit.jacobian` : estimated Jacobian at solution
 
-additionally, it is possible to quiry the degrees of freedom with
+additionally, it is possible to query the degrees of freedom with
 
 * `dof(fit)`
 * `coef(fit)`


### PR DESCRIPTION
'quiry' -> 'query'