### PR TITLE
Fix ambiguity errors for matrix-valued weights

### DIFF
--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -136,7 +136,7 @@ function curve_fit(model, jacobian_model,
     end
 end
 
-function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0::AbstractArray; inplace = false, kwargs...) where T
+function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray, p0::AbstractArray; inplace = false, kwargs...)
     check_data_health(xdata, ydata)
     # construct a weighted cost function, with a vector weight for each ydata
     # for example, this might be wt = 1/sigma where sigma is some error term
@@ -152,7 +152,7 @@ function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, wt::Abstra
 end
 
 function curve_fit(model, jacobian_model,
-            xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T}, p0; inplace = false, kwargs...) where T
+            xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray, p0::AbstractArray; inplace = false, kwargs...)
     check_data_health(xdata, ydata)
     u = sqrt.(wt) # to be consistant with the matrix form
 
@@ -167,7 +167,7 @@ function curve_fit(model, jacobian_model,
     end
 end
 
-function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T,2}, p0; kwargs...) where T
+function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, wt::AbstractMatrix, p0::AbstractArray; kwargs...)
     check_data_health(xdata, ydata)
 
     # as before, construct a weighted cost function with where this
@@ -184,7 +184,7 @@ function curve_fit(model, xdata::AbstractArray, ydata::AbstractArray, wt::Abstra
 end
 
 function curve_fit(model, jacobian_model,
-            xdata::AbstractArray, ydata::AbstractArray, wt::AbstractArray{T,2}, p0; kwargs...) where T
+            xdata::AbstractArray, ydata::AbstractArray, wt::AbstractMatrix, p0::AbstractArray; kwargs...)
     check_data_health(xdata, ydata)
 
     u = cholesky(wt).U

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -47,6 +47,11 @@ let
     @assert norm(fit.param - [1.0, 2.0]) < 0.05
     @test fit.converged
 
+    # test matrix valued weights ( #161 )
+    weights = LinearAlgebra.diagm(1 ./ yvars)
+    fit_matrixweights = curve_fit(model, xdata, ydata, weights, [0.5, 0.5])
+    @test fit.param == fit_matrixweights.param
+
     # can also get error estimates on the fit parameters
     errors = margin_error(fit, 0.1)
     println("norm(errors - [0.017, 0.075]) < 0.1 ?", norm(errors - [0.017, 0.075]))


### PR DESCRIPTION
This addresses #161 and does not have the drawbacks of #162. Since `lmfit()` only accepts initial parameters `p0` of type `AbstractArray` this change should not restrict any function call of `curve_fit()` that worked in previous versions. 