### PR TITLE
Scalarize input

### DIFF
--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -16,9 +16,9 @@ m(t, \boldsymbol{p}) = p_1 \exp(-p_2 t)
 ```
 
 ```julia
-julia> # t: array of independent variable
+julia> # t: independent variable
 julia> # p: array of model parameters
-julia> model(t, p) = p[1] * exp.(-p[2] * t)
+julia> model(t, p) = p[1] * exp(-p[2] * t)
 ```
 
 For illustration purpose, we generate some fake data.
@@ -27,7 +27,7 @@ For illustration purpose, we generate some fake data.
 julia> # tdata: data of independent variable
 julia> # ydata: data of dependent variable
 julia> tdata = range(0, stop=10, length=20)
-julia> ydata = model(tdata, [1.0 2.0]) + 0.01*randn(length(tdata))
+julia> ydata = model.(tdata, Ref([1.0 2.0])) + 0.01*randn(length(tdata))
 ```
 
 Before fitting the data, we also need a initial value of parameters for `curve_fit()`.
@@ -46,7 +46,8 @@ julia> param = fit.param
  2.0735
 ```
 
-`LsqFit.jl` also provides functions to examinep0 = [0.5, 0.5] the goodness of fit. `estimate_covar(fit)` computes the estimated covariance matrix.
+`LsqFit.jl` also provides functions to examine the goodness of fit.
+`estimate_covar(fit)` computes the estimated covariance matrix.
 
 ```Julia
 julia> cov = estimate_covar(fit)

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -31,9 +31,9 @@ Y_i = \gamma_1 \exp(\gamma_2 t_i) + \epsilon_i
 To fit data using `LsqFit.jl`, pass the defined model function (`m`), data (`tdata` and `ydata`) and the initial parameter value (`p0`) to `curve_fit()`. For now, `LsqFit.jl` only supports the Levenberg Marquardt algorithm.
 
 ```julia
-julia> # t: array of independent variables
+julia> # t: independent variable
 julia> # p: array of model parameters
-julia> m(t, p) = p[1] * exp.(p[2] * t)
+julia> m(t, p) = p[1] * exp(p[2] * t)
 julia> p0 = [0.5, 0.5]
 julia> fit = curve_fit(m, tdata, ydata, p0)
 ```
@@ -80,9 +80,9 @@ By default, the finite differences is used (see [NLSolversBase.jl](https://githu
 
 ```Julia
 function j_m(t,p)
-    J = Array{Float64}(length(t),length(p))
-    J[:,1] = exp.(p[2] .* t)       #df/dp[1]
-    J[:,2] = t .* p[1] .* J[:,1]   #df/dp[2]
+    J = Array{Float64}(length(p))
+    J[1] = exp(p[2] * t)       #df/dp[1]
+    J[2] = t * p[1] * J[1]     #df/dp[2]
     J
 end
 
@@ -267,7 +267,7 @@ The algorithm in `LsqFit.jl` will then provide a least squares solution $\boldsy
     In `LsqFit.jl`, the residual function passed to `levenberg_marquardt()` is in different format, if the weight is a vector:
 
     ```julia
-    r(p) = sqrt.(wt) .* ( model(xpts, p) - ydata )
+    r(p) = sqrt.(wt) .* ( model.(xpts, Ref(p)) - ydata )
     lmfit(r, g, p0, wt; kwargs...)
     ```
 

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -16,13 +16,16 @@ StatsBase.residuals(lfr::LsqFitResult) = lfr.resid
 mse(lfr::LsqFitResult) = rss(lfr)/dof(lfr)
 
 function check_data_health(xdata, ydata)
-    if any(ismissing, xdata) || any(ismissing, ydata)
-        error("Data contains `missing` values and a fit cannot be performed")
+    if is_unhealthy(xdata)
+        error("x data contains `missing`, `Inf` or `NaN` values and a fit cannot be performed")
     end
-    if any(isinf, xdata) || any(isinf, ydata) || any(isnan, xdata) || any(isnan, ydata)
-        error("Data contains `Inf` or `NaN` values and a fit cannot be performed")
+    if is_unhealthy(ydata)
+        error("y data contains `missing`, `Inf` or `NaN` values and a fit cannot be performed")
     end
 end
+
+is_unhealthy(x) = ismissing(x) || isinf(x) || isnan(x)
+is_unhealthy(x::AbstractArray) = any(is_unhealthy, x)
 
 # provide a method for those who have their own Jacobian function
 function lmfit(f, g, p0::AbstractArray, wt::AbstractArray; kwargs...)

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -1,11 +1,11 @@
 @testset "curve_fit" begin
     # before testing the model, check whether missing/null data is rejected
     tdata = [rand(1:10, 5)..., missing]
-    @test_throws ErrorException("Data contains `missing` values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
+    @test_throws ErrorException("x data contains `missing`, `Inf` or `NaN` values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
     tdata = [rand(1:10, 5)..., Inf]
-    @test_throws ErrorException("Data contains `Inf` or `NaN` values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
+    @test_throws ErrorException("x data contains `missing`, `Inf` or `NaN` values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
     tdata = [rand(1:10, 5)..., NaN]
-    @test_throws ErrorException("Data contains `Inf` or `NaN` values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
+    @test_throws ErrorException("x data contains `missing`, `Inf` or `NaN` values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
 
     # fitting noisy data to an exponential model
     model(x, p) = p[1] * exp(-x * p[2])

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -1,4 +1,4 @@
-let
+@testset "curve_fit" begin
     # before testing the model, check whether missing/null data is rejected
     tdata = [rand(1:10, 5)..., missing]
     @test_throws ErrorException("Data contains `missing` values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
@@ -6,7 +6,7 @@ let
     @test_throws ErrorException("Data contains `Inf` or `NaN` values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
     tdata = [rand(1:10, 5)..., NaN]
     @test_throws ErrorException("Data contains `Inf` or `NaN` values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
-   
+
     # fitting noisy data to an exponential model
     # TODO: Change to `.-x` when 0.5 support is dropped
     model(x, p) = p[1] .* exp.(-x .* p[2])
@@ -19,12 +19,12 @@ let
 
     for ad in (:finite, :forward, :forwarddiff)
         fit = curve_fit(model, xdata, ydata, p0; autodiff = ad)
-        @assert norm(fit.param - [1.0, 2.0]) < 0.05
+        @test norm(fit.param - [1.0, 2.0]) < 0.05
         @test fit.converged
 
         # can also get error estimates on the fit parameters
         errors = margin_error(fit, 0.1)
-        @assert norm(errors - [0.017, 0.075]) < 0.01
+        @test norm(errors - [0.017, 0.075]) < 0.015
     end
     # if your model is differentiable, it can be faster and/or more accurate
     # to supply your own jacobian instead of using the finite difference
@@ -35,7 +35,7 @@ let
         J
     end
     jacobian_fit = curve_fit(model, jacobian_model, xdata, ydata, p0)
-    @assert norm(jacobian_fit.param - [1.0, 2.0]) < 0.05
+    @test norm(jacobian_fit.param - [1.0, 2.0]) < 0.05
     @test jacobian_fit.converged
 
     # some example data
@@ -44,20 +44,20 @@ let
 
     fit = curve_fit(model, xdata, ydata, 1 ./ yvars, [0.5, 0.5])
     println("norm(fit.param - [1.0, 2.0]) < 0.05 ? ", norm(fit.param - [1.0, 2.0]))
-    @assert norm(fit.param - [1.0, 2.0]) < 0.05
+    @test norm(fit.param - [1.0, 2.0]) < 0.05
     @test fit.converged
 
     # can also get error estimates on the fit parameters
     errors = margin_error(fit, 0.1)
     println("norm(errors - [0.017, 0.075]) < 0.1 ?", norm(errors - [0.017, 0.075]))
-    @assert norm(errors - [0.017, 0.075]) < 0.1
+    @test norm(errors - [0.017, 0.075]) < 0.1
 
     # test with user-supplied jacobian and weights
     fit = curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, p0)
     println("norm(fit.param - [1.0, 2.0]) < 0.05 ? ", norm(fit.param - [1.0, 2.0]))
-    @assert norm(fit.param - [1.0, 2.0]) < 0.05
+    @test norm(fit.param - [1.0, 2.0]) < 0.05
     @test fit.converged
-    
+
     # Parameters can also be inferred using arbitrary precision
     fit = curve_fit(model, xdata, ydata, 1 ./ yvars, BigFloat.(p0); x_tol=1e-20, g_tol=1e-20)
     @test fit.converged

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -8,13 +8,12 @@
     @test_throws ErrorException("Data contains `Inf` or `NaN` values and a fit cannot be performed") LsqFit.check_data_health(tdata, tdata)
 
     # fitting noisy data to an exponential model
-    # TODO: Change to `.-x` when 0.5 support is dropped
-    model(x, p) = p[1] .* exp.(-x .* p[2])
+    model(x, p) = p[1] * exp(-x * p[2])
 
     # some example data
     Random.seed!(12345)
     xdata = range(0, stop=10, length=20)
-    ydata = model(xdata, [1.0, 2.0]) + 0.01*randn(length(xdata))
+    ydata = model.(xdata, Ref([1.0, 2.0])) + 0.01*randn(length(xdata))
     p0 = [0.5, 0.5]
 
     for ad in (:finite, :forward, :forwarddiff)
@@ -29,9 +28,9 @@
     # if your model is differentiable, it can be faster and/or more accurate
     # to supply your own jacobian instead of using the finite difference
     function jacobian_model(x,p)
-        J = Array{Float64}(undef, length(x), length(p))
-        J[:,1] = exp.(-x.*p[2])             #dmodel/dp[1]
-        J[:,2] = -x.*p[1].*J[:,1]           #dmodel/dp[2]
+        J = Array{Float64}(undef, length(p))
+        J[1] = exp(-x*p[2])             #dmodel/dp[1]
+        J[2] = -x*p[1]*J[1]           #dmodel/dp[2]
         J
     end
     jacobian_fit = curve_fit(model, jacobian_model, xdata, ydata, p0)
@@ -40,7 +39,7 @@
 
     # some example data
     yvars = 1e-6*rand(length(xdata))
-    ydata = model(xdata, [1.0, 2.0]) + sqrt.(yvars) .* randn(length(xdata))
+    ydata = model.(xdata, Ref([1.0, 2.0])) + sqrt.(yvars) .* randn(length(xdata))
 
     fit = curve_fit(model, xdata, ydata, 1 ./ yvars, [0.5, 0.5])
     println("norm(fit.param - [1.0, 2.0]) < 0.05 ? ", norm(fit.param - [1.0, 2.0]))

--- a/test/curve_fit_inplace.jl
+++ b/test/curve_fit_inplace.jl
@@ -1,21 +1,21 @@
 @testset "curve_fit_inplace" begin
     # fitting noisy data to an exponential model
     # TODO: Change to `.-x` when 0.5 support is dropped
-    @. model(x, p) = p[1] * exp(-x * p[2])
+    model(x, p) = p[1] * exp(-x * p[2])
     model_inplace(F, x, p) = (@. F = p[1] * exp(-x * p[2]))
 
     # some example data
     Random.seed!(12345)
     xdata = range(0, stop=10, length=500000)
-    ydata = model(xdata, [1.0, 2.0]) + 0.01*randn(length(xdata))
+    ydata = model.(xdata, Ref([1.0, 2.0])) + 0.01*randn(length(xdata))
     p0 = [0.5, 0.5]
 
     # if your model is differentiable, it can be faster and/or more accurate
     # to supply your own jacobian instead of using the finite difference
     function jacobian_model(x,p)
-        J = Array{Float64}(undef, length(x), length(p))
-        @. J[:,1] = exp(-x*p[2])     #dmodel/dp[1]
-        @. @views J[:,2] = -x*p[1]*J[:,1]
+        J = Array{Float64}(undef, length(p))
+        J[1] = exp(-x*p[2])     #dmodel/dp[1]
+        J[2] = -x*p[1]*J[1]
         J
     end
 
@@ -25,8 +25,8 @@
     end
 
 
-    f(p) = model(xdata, p) - ydata
-    g(p) = jacobian_model(xdata, p)
+    f(p) = model.(xdata, Ref(p)) - ydata
+    g(p) = vcat(reshape.(jacobian_model.(xdata, Ref(p)), 1, :)...)
     df = OnceDifferentiable(f, g, p0, similar(ydata); inplace = false);
     evalf(x) = NLSolversBase.value!!(df, x)
     evalg(x) = NLSolversBase.jacobian!!(df, x)
@@ -42,8 +42,8 @@
     j_inplace = evalg_inplace(p0);
 
 
-    @test r == r_inplace
-    @test j == j_inplace
+    @test r ≈ r_inplace
+    @test j ≈ j_inplace
 
     println("--------------\nPerformance of non-inplace")
     println("\t Evaluation function")
@@ -91,7 +91,7 @@
     fit_inplace = @time curve_fit(model_inplace, xdata, ydata, p0; inplace = true, maxIter=100)
     @test fit_inplace.converged
 
-    @test fit_inplace.param == fit.param
+    @test fit_inplace.param ≈ fit.param
 
 
     println("\t Non-inplace with jacobian")
@@ -102,14 +102,14 @@
     fit_inplace_jac = @time curve_fit(model_inplace, jacobian_model_inplace, xdata, ydata, p0; inplace = true, maxIter=100)
     @test fit_inplace_jac.converged
 
-    @test fit_jac.param == fit_inplace_jac.param
+    @test fit_jac.param ≈ fit_inplace_jac.param
 
 
 
 
     # some example data
     yvars = 1e-6*rand(length(xdata))
-    ydata = model(xdata, [1.0, 2.0]) + sqrt.(yvars) .* randn(length(xdata))
+    ydata = model.(xdata, Ref([1.0, 2.0])) + sqrt.(yvars) .* randn(length(xdata))
 
     println("--------------\nPerformance of curve_fit with weights")
 

--- a/test/curve_fit_inplace.jl
+++ b/test/curve_fit_inplace.jl
@@ -1,4 +1,4 @@
-let
+@testset "curve_fit_inplace" begin
     # fitting noisy data to an exponential model
     # TODO: Change to `.-x` when 0.5 support is dropped
     @. model(x, p) = p[1] * exp(-x * p[2])

--- a/test/levenberg_marquardt.jl
+++ b/test/levenberg_marquardt.jl
@@ -10,7 +10,7 @@
 
     R1 = OnceDifferentiable(f_lm, g_lm, zeros(2), zeros(2); inplace = false)
     results = LsqFit.levenberg_marquardt(R1, initial_x)
-    @assert norm(OptimBase.minimizer(results) - [0.0, 2.0]) < 0.01
+    @test norm(OptimBase.minimizer(results) - [0.0, 2.0]) < 0.01
 
 
     function rosenbrock_res(r, x)
@@ -34,7 +34,7 @@
 
     results = LsqFit.levenberg_marquardt(R2, initial_xrb)
 
-    @assert norm(OptimBase.minimizer(results) - [1.0, 1.0]) < 0.01
+    @test norm(OptimBase.minimizer(results) - [1.0, 1.0]) < 0.01
 
     # check estimate is within the bound PR #278
     result = LsqFit.levenberg_marquardt(R2, [150.0, 150.0]; lower = [10.0, 10.0], upper = [200.0, 200.0])
@@ -60,7 +60,7 @@
         R3 = OnceDifferentiable(f_lsq, g_lsq, zeros(2), zeros(_nobs); inplace = false)
         results = LsqFit.levenberg_marquardt(R3, [0.5, 0.5])
 
-        @assert norm(OptimBase.minimizer(results) - [1.0, 2.0]) < 0.05
+        @test norm(OptimBase.minimizer(results) - [1.0, 2.0]) < 0.05
     end
 
     let


### PR DESCRIPTION
This is a breaking change, but one that I really feel makes `LsqFit` more Julian. Would close #145 

Instead of 
```julia
model(x, p) = exp.( - ( x .- p[1] ).^2 ./ p[2]^2 )
```
the model definition (the operation which involves the user the most) becomes
```julia
model(x, p) = exp( - ( x - p[1] )^2 / p[2]^2 )
```
i.e. the user doesn't need to think about the shape of `x`, they just define the behavior with respect to a scalar.

From the tests, it looks like you are just moving the complexity from the model definition to the data generation
(which goes from `y = model(x, p)` to `y = model.(x, Ref(p))`), but note that in real world cases you wouldn't be generating the data from your own model like this.

One part that I'm a bit uncertain about is multivariate models: I've currently written it so that the `x` argument for `curve_fit` is a `AbstractArray{AbstractArray}` (e.g. `[ [1.0, 3.0], [2.0, 3.4], [1.5, 2.0] ]` for a two-variable function with three datapoints). One might want to go through and change this to accept matrices, I just haven't (yet). There are afaict currently no tests for multivariate fitting either.

Oh, and the tests weren't passing (some of them even crashed) before, so I relaxed them a bit in the first commit.

Are you interested?