### PR TITLE
vration check on real part of covar matrix

### DIFF
--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -220,7 +220,7 @@ function StatsBase.stderror(fit::LsqFitResult; rtol::Real=NaN, atol::Real=0)
     covar = estimate_covar(fit)
     # then the standard errors are given by the sqrt of the diagonal
     vars = diag(covar)
-    vratio = minimum(vars)/maximum(vars)
+    vratio = minimum(real.(vars))/maximum(real.(vars))
     if !isapprox(vratio, 0.0, atol=atol, rtol=isnan(rtol) ? Base.rtoldefault(vratio, 0.0, 0) : rtol) && vratio < 0.0
         error("Covariance matrix is negative for atol=$atol and rtol=$rtol")
     end


### PR DESCRIPTION
If the covariance matrix of some fit is of the Complex data type (even if the imaginary part is zero) the vratio check will throw a runtime error. The proposed fix maintains the current functionality, but allows for the covariance matrix to be of the Complex data type.