### PR TITLE
Hdf5 read write capabilities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.12.1"
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLSolversBase = "d41bc354-129a-5804-8e4c-c37616107c6c"
 OptimBase = "87e2bd06-a317-5318-96d9-3ecbac512eee"

--- a/src/LsqFit.jl
+++ b/src/LsqFit.jl
@@ -14,6 +14,7 @@ module LsqFit
     using OptimBase
     using LinearAlgebra
     using ForwardDiff
+    using HDF5 
     import NLSolversBase: value, jacobian
     import StatsBase
     import StatsBase: coef, dof, nobs, rss, stderror, weights, residuals

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -7,28 +7,32 @@ struct LsqFitResult{P, R, J, W <: AbstractArray}
 end
 
 function HDF5.write(parent::Union{HDF5.File,HDF5.Group}, name::AbstractString, fit::LsqFitResult)
-  g = create_group(parent, name)
-  attributes(g)["type"] = "LsqFitResult"
-  attributes(g)["version"] = 1
+    g = create_group(parent, name)
+    attributes(g)["type"] = "LsqFitResult"
+    attributes(g)["version"] = 1
 
-  write(g, "param", fit.param)
-  write(g, "resid", fit.resid)
-  write(g, "jacobian", fit.jacobian)
-  write(g, "converged", fit.converged)
-  write(g, "wt", fit.wt)
+    write(g, "param", fit.param)
+    write(g, "resid", fit.resid)
+    write(g, "jacobian", fit.jacobian)
+    write(g, "converged", fit.converged)
+    write(g, "wt", fit.wt)
 end
 
 function HDF5.read(parent::Union{HDF5.File,HDF5.Group}, name::AbstractString, ::Type{LsqFitResult})
-  g = open_group(parent, name)
-  if read(attributes(g)["type"]) != "LsqFitResult"
+    g = open_group(parent, name)
+    if read(attributes(g)["type"]) != "LsqFitResult"
     error("HDF5 group or file does not contain LsqFitResult data")
-  end
-  param = read(g, "param")
-  resid = read(g, "resid")
-  jacobian = read(g, "jacobian")
-  converged = read(g, "converged")
-  wt = read(g, "wt")
-  return LsqFitResult(param, resid, jacobian, converged, wt)
+    end
+    if read(attributes(g)["version"]) == 1
+        param = read(g, "param")
+        resid = read(g, "resid")
+        jacobian = read(g, "jacobian")
+        converged = read(g, "converged")
+        wt = read(g, "wt")
+        return LsqFitResult(param, resid, jacobian, converged, wt)
+    else
+        error("Found LsqFit data in HDF5 data but the data version is not supported by this version of LsqFit.jl\n Found data version number $(read(attributes(g)["version"]))")
+    end
 end
 
 StatsBase.coef(lfr::LsqFitResult) = lfr.param

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -6,6 +6,30 @@ struct LsqFitResult{P, R, J, W <: AbstractArray}
     wt::W
 end
 
+function HDF5.write(parent::Union{HDF5.File,HDF5.Group}, name::AbstractString, fit::LsqFitResult)
+  g = create_group(parent, name)
+  attributes(g)["type"] = "LsqFitResult"
+  attributes(g)["version"] = 1
+
+  write(g, "param", fit.param)
+  write(g, "resid", fit.resid)
+  write(g, "jacobian", fit.jacobian)
+  write(g, "converged", fit.converged)
+  write(g, "wt", fit.wt)
+end
+
+function HDF5.read(parent::Union{HDF5.File,HDF5.Group}, name::AbstractString, ::Type{LsqFitResult})
+  g = open_group(parent, name)
+  if read(attributes(g)["type"]) != "LsqFitResult"
+    error("HDF5 group or file does not contain LsqFitResult data")
+  end
+  param = read(g, "param")
+  resid = read(g, "resid")
+  jacobian = read(g, "jacobian")
+  converged = read(g, "converged")
+  wt = read(g, "wt")
+  return LsqFitResult(param, resid, jacobian, converged, wt)
+end
 
 StatsBase.coef(lfr::LsqFitResult) = lfr.param
 StatsBase.dof(lfr::LsqFitResult) = nobs(lfr) - length(coef(lfr))

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -65,4 +65,21 @@ let
     @test fit.converged
 
     curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, [0.5, 0.5]; tau=0.0001)
+    
+    fo = h5open("data.h5", "w")
+        write(fo, "FitResults", fit)
+    close(fo)
+    
+    fi = h5open("data.h5", "r")
+        fit_read = read(fi, "FitResults", LsqFit.FitResult)
+    close(fi)
+    
+    @test prod([
+        norm(fit_read.params - fit.params) / norm(fit.params) < 1E-10,  
+        norm(fit_read.resid - fit.resid) / norm(fit.resid) < 1E-10,
+        norm(fit_read.jacobian - fit.jacobian) / norm(fit.jacobian) < 1E-10,
+        fit_read.converged == fit.converged,
+        norm(fit_read.wt - fit.wt) / norm(fit.wt) < 1E-10
+    ])
+    
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@
 #
 using LsqFit, Test, LinearAlgebra, Random
 using OptimBase
+using HDF5
 import NLSolversBase: OnceDifferentiable
 
 my_tests = ["curve_fit.jl", "levenberg_marquardt.jl", "curve_fit_inplace.jl", "geodesic.jl"]


### PR DESCRIPTION
Hello guys,
This PR adds functionality to read/write Fits to disk in the HDF5 file format.

I am new to this repo and project, so I wish to apologies in advance if you already discussed this subject and concluded not to take this route and add the overhead of HDF5 to this simple package.
However, while I was analysing some large amount of data I wanted to save the fits that I performed and be able to quickly read and compare slight different approached as the fit was somewhat heavy and rerunning the code would have been infeasible. 

I would understand if you wished not to add the HDF5 dependency to this package. Let me know what you think!