### PR TITLE
Fix estimate_covar in case of !isempty(fit.wt)

### DIFF
--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -260,7 +260,11 @@ function StatsAPI.vcov(fit::LsqFitResult)
     if isempty(fit.wt)
         r = fit.resid
 
-        # compute the covariance matrix from the QR decomposition
+        # compute the covariance matrix from the QR decomposition (J = QR):
+        # => inv(J' J) = inv(J) * inv(J')
+        #              = inv(QR) * inv(R'Q')
+        #              = inv(R)inv(Q) * inv(Q')inv(R') | with Q' = inv(Q)
+        #              = inv(R) * inv(R')
         Q, R = qr(J)
         Rinv = inv(R)
         covar = Rinv * Rinv' * mse(fit)

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -258,8 +258,6 @@ function StatsAPI.vcov(fit::LsqFitResult)
     J = fit.jacobian
 
     if isempty(fit.wt)
-        r = fit.resid
-
         # compute the covariance matrix from the QR decomposition (J = QR):
         # => inv(J' J) = inv(J) * inv(J')
         #              = inv(QR) * inv(R'Q')

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -265,7 +265,7 @@ function StatsAPI.vcov(fit::LsqFitResult)
         Rinv = inv(R)
         covar = Rinv * Rinv' * mse(fit)
     else
-        covar = inv(J' * J)
+        covar = inv(J' * fit.wt * J)
     end
 
     return covar


### PR DESCRIPTION
While trying to figure out how LsqFit determines the covariance of the fit parameters, I found this inconsistency between the two used methods in `estimate_covar`. According to your own docs this factor of sigma^2 is missing at one occasion. I also documented the relation used for the QR decomposition because at least for me this wasn't obvious.

I'm also not sure why there is this special casing for isempty(fit.wt) in the first place since the two methods are mathematically identical but I didn't want to make any wrong assumptions here and therefore only added the fix to the existing case.

Edit: Looking a bit through git blame, it seems like the original idea was to use the weights in this position:
https://github.com/JuliaNLSolvers/LsqFit.jl/commit/55eefde8a36f8f2f2b75ec18053f6d2dd1e20756#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R76
Which was then later removed.

To me, using the inverse weights as variance might somehow make sense, but in the current state I'm pretty sure it is just wrong, it is equivalent to setting sigma^2 = 1.