### PR TITLE
Support StaticArrays (`MVector`)

### DIFF
--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -27,8 +27,8 @@ end
 
 struct LMResults{O,T,Tval,N}
     method::O
-    initial_x::Array{T,N}
-    minimizer::Array{T,N}
+    initial_x::AbstractArray{T,N}
+    minimizer::AbstractArray{T,N}
     minimum::Tval
     iterations::Int
     iteration_converged::Bool
@@ -146,8 +146,8 @@ function levenberg_marquardt(
     # Create buffers
     n = length(x)
     m = length(value(df))
-    JJ = Matrix{T}(undef, n, n)
-    n_buffer = Vector{T}(undef, n)
+    JJ = transpose(jacobian(df))*jacobian(df)
+    n_buffer = similar(x)
     Jdelta_buffer = similar(value(df))
 
     # and an alias for the jacobian

--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -25,10 +25,10 @@ function Base.show(io::IO, tr::LMTrace)
     return
 end
 
-struct LMResults{O,T,Tval,N}
+struct LMResults{O,T,Tval,N,Arr<:AbstractArray{T, N}}
     method::O
-    initial_x::AbstractArray{T,N}
-    minimizer::AbstractArray{T,N}
+    initial_x::Arr
+    minimizer::Arr
     minimum::Tval
     iterations::Int
     iteration_converged::Bool


### PR DESCRIPTION
This package is almost ready to be used straight up with StaticArrays.
Most variables are already written in a general way, there are just two
blockers:
The preallocated buffers `JJ` and `n_buffer`, aswell as the LMResults
type.

This PR fixes that, and almost allows usage of StaticArrays.
However, there's still
https://github.com/JuliaDiff/DiffResults.jl/issues/25, but that can be
currently overcome by two function definitions shows in the PR.
