### PR TITLE
Fix documentation deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 benchmarks/graphs/*
 *~
 *.kate-swp
+*.jl.cov
+*.jl.*.cov
+*.jl.mem
+/docs/build/
+Manifest.toml

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LsqFit = "2fda8390-95c7-5789-9bda-21331edee243"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,7 @@ makedocs(
     format = Documenter.HTML(prettyurls = true, canonical="https://julianlsolvers.github.io/LsqFit.jl/stable/"),
     sitename = "LsqFit.jl",
     doctest = false,
-    strict = false,
+    warnonly = true,
     pages = Any[
             "Home" => "index.md",
             "Getting Started" => "getting_started.md",


### PR DESCRIPTION
There was no compatibility set for the Documenter dependency in `docs/Project.toml`, so a breaking change made in Documenter 1.0 broke documentation deployment for this package. In particular, the `strict` keyword argument in `makedocs` was replaced with `warnonly`. To fix it, we can declare explicit compatibility with Documenter 1.0 and switch to using `warnonly=true` rather than `strict=false`.

As part of this, I've also added standard entries to `.gitignore`, two of which are relevant to documentation: the automatically generated `docs/build/` directory and `Manifest.toml`.