### PR TITLE
Create Measurements package extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,16 +10,24 @@ NLSolversBase = "d41bc354-129a-5804-8e4c-c37616107c6c"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 
+[weakdeps]
+Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+
+[extensions]
+MeasurementsExt = "Measurements"
+
 [compat]
 Distributions = "0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
 ForwardDiff = "0.10"
+Measurements = "2.10"
 NLSolversBase = "7.5"
 StatsAPI = "1"
 julia = "1.6"
 
 [extras]
+Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "StableRNGs"]
+test = ["Test", "StableRNGs", "Measurements"]

--- a/ext/MeasurementsExt.jl
+++ b/ext/MeasurementsExt.jl
@@ -1,0 +1,20 @@
+module MeasurementsExt
+
+using LsqFit
+isdefined(Base, :get_extension) ? (using Measurements) : (using ..Measurements)
+
+function LsqFit.curve_fit(
+    model,
+    xdata::AbstractArray,
+    ydata::AbstractArray{Measurement{T}} where T,
+    p0::AbstractArray;
+    inplace=false,
+    kwargs...,
+)
+    y = Measurements.value.(ydata)
+    ye = Measurements.uncertainty.(ydata)
+    wt = ye .^ -2
+    curve_fit(model, xdata, y, wt, p0; inplace=inplace, kwargs...)
+end
+
+end # module

--- a/src/LsqFit.jl
+++ b/src/LsqFit.jl
@@ -28,6 +28,16 @@ using StatsAPI: coef, confint, dof, nobs, rss, stderror, weights, residuals, vco
 
 import Base.summary
 
+# 
+function __init__()
+    @static if !isdefined(Base, :get_extension)
+        @require Measurements="eff96d63-e80a-5855-80a2-b1b0885c5ab7" begin
+             include("../ext/MeasurementsExt.jl")
+         end
+    end
+end
+
+
 include("geodesic.jl")
 include("levenberg_marquardt.jl")
 include("curve_fit.jl")

--- a/test/measurements.jl
+++ b/test/measurements.jl
@@ -1,0 +1,15 @@
+using LsqFit
+using Measurements
+
+@testset "MeasurementsExt" begin
+    model(x, p) = p[1] .* exp.(-x .* p[2])
+    ptrue = [10, 0.3]
+    x = LinRange(0, 2, 50)
+    y0 = model(x, ptrue)
+    σ = rand(1:5, 50)
+    y = y0 .± σ
+    wt = σ .^ -2
+    fit0 = curve_fit(model, x, y0, wt, ptrue) # fit to data using weights
+    fit1 = curve_fit(model, x, y, ptrue) # fit to data using Measurements
+    @test coef(fit0) ≈ coef(fit1)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@
 using LsqFit, Test, LinearAlgebra
 using NLSolversBase
 
-my_tests = ["curve_fit.jl", "levenberg_marquardt.jl", "curve_fit_inplace.jl", "geodesic.jl"]
+my_tests = ["curve_fit.jl", "levenberg_marquardt.jl", "curve_fit_inplace.jl", "geodesic.jl", "measurements.jl"]
 
 println("Running tests:")
 


### PR DESCRIPTION
This PR creates a simple extension for the [Measurements package](https://github.com/JuliaPhysics/Measurements.jl), allowing data with uncertainties to be passed directly for fitting, e.g.:

```julia
using LsqFit, Measurements
x = [1.0, 2.0, 3.0]
y = [1 ± 0.1, 2.2 ± 0.2, 2.9 ± 0.3]
model(x, p) = p[1] * x
p0 = [1.]
curve_fit(model, x, y, p0)
```

The extension creates a simple wrapper for `LsqFit.curve_fit` that dispatches on `ydata::AbstractArray{Measurement{T}} where T`. Values and uncertainties are extracted from the input, then weights are calculated as the inverse square of the uncertainties and passed to the main `curve_fit` function.

A unit test checks that the extension gives the same results as when weights are passed manually.

An `__init__` function is defined in `LsqFit.jl` to load the extension for Julia versions <1.9 (see discussion at https://discourse.julialang.org/t/package-extensions-for-julia-1-9/93397).