### PR TITLE
curve_fit.jl: fix #255

### DIFF
--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -256,17 +256,10 @@ end
 function StatsAPI.vcov(fit::LsqFitResult)
     # computes covariance matrix of fit parameters
     J = fit.jacobian
-
-    if isempty(fit.wt)
-        r = fit.resid
-
-        # compute the covariance matrix from the QR decomposition
-        Q, R = qr(J)
-        Rinv = inv(R)
-        covar = Rinv * Rinv' * mse(fit)
-    else
-        covar = inv(J' * J)
-    end
+    # compute from the QR decomposition of the Jacobian
+    Q, R = qr(J)
+    Rinv = inv(R)
+    covar = Rinv * Rinv' * mse(fit)
 
     return covar
 end


### PR DESCRIPTION
fixes #255
- use always the MSE and us QR decomposition for the calculation
- remove unused code line