### PR TITLE
fix link to documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ LsqFit.jl
 The LsqFit package is a small library that provides basic least-squares fitting in pure Julia under an MIT license. The basic functionality was originally in [Optim.jl](https://github.com/JuliaNLSolvers/Optim.jl), before being separated into this library.  At this time, `LsqFit` only utilizes the Levenberg-Marquardt algorithm for non-linear fitting.
 
 [![CI](https://github.com/JuliaNLSolvers/LsqFit.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/JuliaNLSolvers/LsqFit.jl/actions/workflows/ci.yml)
-[![latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://julianlsolvers.github.io/LsqFit.jl/latest/)
+[![latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://julianlsolvers.github.io/LsqFit.jl/dev/)
 
 Basic Usage
 -----------


### PR DESCRIPTION
The link to the documentation points to an outdated version (by several years). This PR fixes that.