### PR TITLE
Change julia version in CI to 'min'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             version: 1
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}


### PR DESCRIPTION
julia-actions/setup-julia can now automatically look at Project.toml and setup the earliest supported version of Julia without needing to explicitly specify