### PR TITLE
Add Aqua and JET quality assurance tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,16 +13,24 @@ StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 
 [compat]
 ADTypes = "1"
+Aqua = "0.8"
 Distributions = "0.18, 0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
 ForwardDiff = "0.10, 1.0"
+JET = "0.9, 0.10, 0.11"
+LinearAlgebra = "1"
 NLSolversBase = "8"
+Printf = "1"
+StableRNGs = "1"
 StatsAPI = "1"
+Test = "1"
 julia = "1.10"
 
 [extras]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ADTypes", "Test", "StableRNGs"]
+test = ["ADTypes", "Test", "StableRNGs", "Aqua", "JET"]

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -1,0 +1,18 @@
+using LsqFit
+using Test
+import Aqua
+import JET
+
+@testset "QA" begin
+    @testset "Aqua" begin
+        Aqua.test_all(LsqFit)
+    end
+
+    @testset "JET" begin
+        # Check that there are no undefined global references and undefined field accesses
+        JET.test_package(LsqFit; target_modules = (LsqFit,), mode = :typo)
+
+        # Analyze methods based on their declared signature
+        JET.test_package(LsqFit; target_modules = (LsqFit,))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,8 @@
 using LsqFit, Test, LinearAlgebra
 using NLSolversBase
 
-my_tests = ["curve_fit.jl", "levenberg_marquardt.jl", "curve_fit_inplace.jl", "geodesic.jl"]
+my_tests =
+    ["curve_fit.jl", "levenberg_marquardt.jl", "curve_fit_inplace.jl", "geodesic.jl", "qa.jl"]
 
 println("Running tests:")
 


### PR DESCRIPTION
Brings LsqFit's test suite up to the same QA baseline as Optim.jl.

## What this adds

- **`test/qa.jl`** mirroring Optim's `qa.jl`:
  - `Aqua.test_all(LsqFit)` — method ambiguities, unbound type params, undefined exports, piracy, stale deps, compat bounds, persistent tasks.
  - `JET.test_package(LsqFit)` in both `:typo` mode (undefined globals/field accesses) and default signature-analysis mode.
- Wires `qa.jl` into `test/runtests.jl`.
- Adds `Aqua` and `JET` as test dependencies (`[extras]`/`[targets]`) with `[compat]` bounds matching Optim's (`Aqua = "0.8"`, `JET = "0.9, 0.10, 0.11"`).
- Adds the `[compat]` entries Aqua's deps/extras checks require: `LinearAlgebra`, `Printf`, `StableRNGs`, `Test`.

## Result

Locally on Julia 1.11.9 the QA testset is fully green (13/13) — Aqua and JET both pass with no code changes needed beyond the compat additions.

---

This pull request was written with the assistance of generative AI (Claude Code).