### PR TITLE
Rework weights

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLSolversBase = "d41bc354-129a-5804-8e4c-c37616107c6c"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 ADTypes = "1"
@@ -22,6 +23,7 @@ NLSolversBase = "8"
 Printf = "1"
 StableRNGs = "1"
 StatsAPI = "1"
+StatsBase = "0.33, 0.34"
 Test = "1"
 julia = "1.10"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LsqFit"
 uuid = "2fda8390-95c7-5789-9bda-21331edee243"
-version = "0.16.0"
+version = "0.17.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Existing Functionality
 * `jacobian`: (optional) function that returns the Jacobian matrix of `model`
 * `x`: the independent variable
 * `y`: the dependent variable that constrains `model`
-* `w`: (optional) weight applied to the residual; can be a vector (of `length(x)` size or empty) or matrix (inverse covariance matrix)
+* `w`: (optional) weight applied to the residual; use `PrecisionWeights(1 ./ σ.^2)` (or `PrecisionMatrix(inv(Σ))` for correlated errors) when the variances are known, or `AnalyticWeights`/`FrequencyWeights` to estimate the scale. Passing a bare vector or matrix still works but is deprecated.
 * `p0`: initial guess of the model parameters
 * `kwargs`: tuning parameters for fitting, passed to `levenberg_marquardt`, such as `maxIter`, `show_trace` or `lower` and `upper` bounds
 * `fit`: composite type of results (`LsqFitResult`)

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,9 +2,10 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LsqFit = "2fda8390-95c7-5789-9bda-21331edee243"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-
-[compat]
-Documenter = "1"
+SummaryTables = "6ce4ecf0-73a7-4ce3-9fb4-80ebfe887b60"
 
 [sources]
 LsqFit = {path = ".."}
+
+[compat]
+Documenter = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LsqFit = "2fda8390-95c7-5789-9bda-21331edee243"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,7 @@ makedocs(
         "Home"=>"index.md",
         "Getting Started"=>"getting_started.md",
         "Tutorial"=>"tutorial.md",
+        "Weights"=>"weights.md",
         "API References"=>"api.md",
     ],
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -5,3 +5,10 @@ Private = false
 Pages   = ["curve_fit.jl"]
 Order   = [:function]
 ```
+
+## Weight types
+
+```@docs
+PrecisionWeights
+PrecisionMatrix
+```

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -327,7 +327,9 @@ If we only know **the relative ratio of different variances**, i.e. ``ε \sim N(
 \mathbf{Cov}(\boldsymbol{γ}^*) = σ^2[J'WJ]^{-1}
 ```
 
-where ``σ^2`` is estimated. In this case, if we set ``W = I``, the result will be the same as the unweighted version. However, `curve_fit()` currently **does not support** this implementation. `curve_fit()` assumes the weight as the inverse of **the error covariance matrix** rather than **the ratio of error covariance matrix**, i.e. the covariance of the estimated parameter is calculated as `covar = inv(J'*fit.wt*J)`.
+where ``σ^2`` is estimated. In this case, if we set ``W = I``, the result will be the same as the unweighted version. However, `curve_fit()` currently **does not support** this implementation. `curve_fit()` assumes the weight as the inverse of **the error covariance matrix** rather than **the ratio of error covariance matrix**, i.e. the covariance of the estimated parameter is calculated as ``[J'WJ]^{-1}``.
+
+Note that `fit.jacobian` already has the weights folded in (the residuals, and therefore the Jacobian, are scaled by ``\sqrt{W}``). So in terms of the stored Jacobian the implementation simply computes `inv(J'J)`, which equals ``[J_\text{raw}'WJ_\text{raw}]^{-1}``. No mean-squared-error factor is applied in the weighted case, which is why passing a weight vector of ones is **not** equivalent to an unweighted fit for covariance purposes (see the note below).
 
 !!! note
     Passing vector of ones as the weight vector will cause mistakes in covariance estimation.

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -321,9 +321,9 @@ The covariance matrix is now:
 ```
 
 
-This is the case in which you **know the error variances exactly**. Pass them
-as a bare vector `1 ./ var(ε)` or, for correlated errors, as the inverse
-covariance matrix `inv(cov_ε)`:
+This is the case in which the error variances are known exactly. Pass them as a
+bare vector `1 ./ var(ε)`, or as the inverse covariance matrix `inv(cov_ε)` for
+correlated errors:
 
 ```Julia
 wt = inv(cov_ε)
@@ -331,33 +331,29 @@ fit = curve_fit(m, tdata, ydata, wt, p0)
 cov = vcov(fit)
 ```
 
-If instead you only know **the relative ratio of the variances**, i.e.
-``ε \sim N(0, σ^2 W^{-1})`` with an unknown common scale ``σ^2``, the covariance
-matrix is
+If the variances are known only up to a common factor,
+``ε \sim N(0, σ^2 W^{-1})`` with unknown ``σ^2``, the covariance is
 
 ```math
 \mathbf{Cov}(\boldsymbol{γ}^*) = σ^2[J'WJ]^{-1}
 ```
 
-where ``σ^2`` is **estimated** from the residuals. This is what MATLAB
-`nlinfit`, Origin and LabPlot do, and it is requested by wrapping the same
-inverse-variance numbers in [`AnalyticWeights`](@ref):
+with ``σ^2`` estimated from the residuals. This is what MATLAB `nlinfit`, Origin
+and LabPlot do. Wrap the same inverse-variance numbers in
+[`AnalyticWeights`](@ref) to get it:
 
 ```Julia
 fit = curve_fit(m, tdata, ydata, AnalyticWeights(1 ./ var(ε)), p0)
 ```
 
-Because the scale is estimated, `AnalyticWeights` are **scale-invariant**:
-multiplying every weight by a constant leaves `vcov(fit)` unchanged, and uniform
+`AnalyticWeights` do not depend on the overall scale of the weights, so uniform
 weights reproduce the unweighted fit.
 
-!!! warning "A bare vector and `AnalyticWeights` are not the same"
-    A **bare vector** treats the weights as the *exact* inverse variances
-    (`σ² ≡ 1`, no scale estimated). `AnalyticWeights` treats them as *relative*
-    precisions and estimates the scale. They give different `stderror`s. Passing
-    a vector of ones is therefore *not* equivalent to an unweighted fit, but
-    `AnalyticWeights(ones(n))` is. See the [Weights](@ref) page for a full
-    treatment with Monte-Carlo coverage checks.
+A bare vector and `AnalyticWeights` are not the same: the bare vector takes the
+weights as exact inverse variances (no scale estimated), `AnalyticWeights` takes
+them as relative precisions and estimates the scale, and they give different
+standard errors. A vector of ones is not equivalent to an unweighted fit, but
+`AnalyticWeights(ones(n))` is. The [Weights](@ref) page covers this in detail.
 
 !!! note
     If the weight matrix is not a diagonal matrix, General Least Squares will be performed.

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -340,7 +340,7 @@ If the variances are known only up to a common factor,
 
 with ``σ^2`` estimated from the residuals. This is what MATLAB `nlinfit`, Origin
 and LabPlot do. Wrap the same inverse-variance numbers in
-[`AnalyticWeights`](@ref) to get it:
+`AnalyticWeights` to get it:
 
 ```Julia
 fit = curve_fit(m, tdata, ydata, AnalyticWeights(1 ./ var(ε)), p0)

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -321,15 +321,19 @@ The covariance matrix is now:
 ```
 
 
-This is the case in which the error variances are known exactly. Pass them as a
-bare vector `1 ./ var(ε)`, or as the inverse covariance matrix `inv(cov_ε)` for
+This is the case in which the error variances are known exactly. Wrap them in
+`PrecisionWeights(1 ./ var(ε))`, or in `PrecisionMatrix(inv(cov_ε))` for
 correlated errors:
 
 ```Julia
-wt = inv(cov_ε)
+wt = PrecisionMatrix(inv(cov_ε))
 fit = curve_fit(m, tdata, ydata, wt, p0)
 cov = vcov(fit)
 ```
+
+!!! warning "Deprecated"
+    Passing a bare `1 ./ var(ε)` vector or `inv(cov_ε)` matrix still works but is
+    deprecated; use `PrecisionWeights` / `PrecisionMatrix` instead.
 
 If the variances are known only up to a common factor,
 ``ε \sim N(0, σ^2 W^{-1})`` with unknown ``σ^2``, the covariance is
@@ -349,11 +353,12 @@ fit = curve_fit(m, tdata, ydata, AnalyticWeights(1 ./ var(ε)), p0)
 `AnalyticWeights` do not depend on the overall scale of the weights, so uniform
 weights reproduce the unweighted fit.
 
-A bare vector and `AnalyticWeights` are not the same: the bare vector takes the
-weights as exact inverse variances (no scale estimated), `AnalyticWeights` takes
-them as relative precisions and estimates the scale, and they give different
-standard errors. A vector of ones is not equivalent to an unweighted fit, but
-`AnalyticWeights(ones(n))` is. The [Weights](@ref) page covers this in detail.
+`PrecisionWeights` and `AnalyticWeights` are not the same: `PrecisionWeights` take
+the weights as exact inverse variances (no scale estimated), `AnalyticWeights` take
+them as relative precisions and estimate the scale, and they give different
+standard errors. `PrecisionWeights(ones(n))` is not equivalent to an unweighted
+fit, but `AnalyticWeights(ones(n))` is. The [Weights](@ref) page covers this in
+detail.
 
 !!! note
     If the weight matrix is not a diagonal matrix, General Least Squares will be performed.
@@ -367,10 +372,11 @@ Set the weight matrix as the inverse of the error covariance matrix (the optimal
 \mathbf{Cov}(\boldsymbol{γ}^*) ≈ [J'WJ]^{-1}J'W \Sigma W'J[J'W'J]^{-1} = [J'WJ]^{-1}
 ```
 
-Pass the matrix `inv(covar(ε))` as the weight parameter (`wt`) to the function `curve_fit()`:
+Pass the matrix `inv(covar(ε))`, wrapped in `PrecisionMatrix`, as the weight
+parameter (`wt`) to the function `curve_fit()`:
 
 ```Julia
-wt = 1 ./ yvar
+wt = PrecisionMatrix(inv(covar(ε)))
 fit = curve_fit(m, tdata, ydata, wt, p0)
 cov = vcov(fit)
 ```
@@ -386,7 +392,7 @@ Unweighted fitting (OLS) will return the residuals we need, since the estimator 
 
 ```Julia
 fit_OLS = curve_fit(m, tdata, ydata, p0)
-wt = 1 ./ fit_OLS.resid
+wt = AnalyticWeights(1 ./ fit_OLS.resid)
 fit_WLS = curve_fit(m, tdata, ydata, wt, p0)
 cov = vcov(fit_WLS)
 ```

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -321,26 +321,43 @@ The covariance matrix is now:
 ```
 
 
-If we only know **the relative ratio of different variances**, i.e. ``ε \sim N(0, σ^2 W^{-1})``, the covariance matrix will be:
-
-```math
-\mathbf{Cov}(\boldsymbol{γ}^*) = σ^2[J'WJ]^{-1}
-```
-
-where ``σ^2`` is estimated. In this case, if we set ``W = I``, the result will be the same as the unweighted version. However, `curve_fit()` currently **does not support** this implementation. `curve_fit()` assumes the weight as the inverse of **the error covariance matrix** rather than **the ratio of error covariance matrix**, i.e. the covariance of the estimated parameter is calculated as ``[J'WJ]^{-1}``.
-
-Note that `fit.jacobian` already has the weights folded in (the residuals, and therefore the Jacobian, are scaled by ``\sqrt{W}``). So in terms of the stored Jacobian the implementation simply computes `inv(J'J)`, which equals ``[J_\text{raw}'WJ_\text{raw}]^{-1}``. No mean-squared-error factor is applied in the weighted case, which is why passing a weight vector of ones is **not** equivalent to an unweighted fit for covariance purposes (see the note below).
-
-!!! note
-    Passing vector of ones as the weight vector will cause mistakes in covariance estimation.
-
-Pass the vector of `1 ./ var(ε)` or the matrix `inv(covar(ε))` as the weight parameter (`wt`) to the function `curve_fit()`:
+This is the case in which you **know the error variances exactly**. Pass them
+as a bare vector `1 ./ var(ε)` or, for correlated errors, as the inverse
+covariance matrix `inv(cov_ε)`:
 
 ```Julia
 wt = inv(cov_ε)
 fit = curve_fit(m, tdata, ydata, wt, p0)
 cov = vcov(fit)
 ```
+
+If instead you only know **the relative ratio of the variances**, i.e.
+``ε \sim N(0, σ^2 W^{-1})`` with an unknown common scale ``σ^2``, the covariance
+matrix is
+
+```math
+\mathbf{Cov}(\boldsymbol{γ}^*) = σ^2[J'WJ]^{-1}
+```
+
+where ``σ^2`` is **estimated** from the residuals. This is what MATLAB
+`nlinfit`, Origin and LabPlot do, and it is requested by wrapping the same
+inverse-variance numbers in [`AnalyticWeights`](@ref):
+
+```Julia
+fit = curve_fit(m, tdata, ydata, AnalyticWeights(1 ./ var(ε)), p0)
+```
+
+Because the scale is estimated, `AnalyticWeights` are **scale-invariant**:
+multiplying every weight by a constant leaves `vcov(fit)` unchanged, and uniform
+weights reproduce the unweighted fit.
+
+!!! warning "A bare vector and `AnalyticWeights` are not the same"
+    A **bare vector** treats the weights as the *exact* inverse variances
+    (`σ² ≡ 1`, no scale estimated). `AnalyticWeights` treats them as *relative*
+    precisions and estimates the scale. They give different `stderror`s. Passing
+    a vector of ones is therefore *not* equivalent to an unweighted fit, but
+    `AnalyticWeights(ones(n))` is. See the [Weights](@ref) page for a full
+    treatment with Monte-Carlo coverage checks.
 
 !!! note
     If the weight matrix is not a diagonal matrix, General Least Squares will be performed.

--- a/docs/src/weights.md
+++ b/docs/src/weights.md
@@ -1,0 +1,250 @@
+# Weights
+
+Weighted least squares is where most of the confusion about LsqFit's uncertainty
+estimates comes from. This page makes the roles of **standard deviation**,
+**variance** and **covariance** explicit, derives the two covariance formulas,
+shows them on a worked example, and finally *verifies* them with a Monte-Carlo
+coverage study so you can trust the numbers rather than take them on faith.
+
+The short version:
+
+* The weight **values** you pass are always **inverse variances**
+  (`wᵢ = 1/σᵢ²`), never standard deviations.
+* The weight **type** decides whether the overall noise scale `σ²` is treated as
+  **known** (`vcov = (JᵀWJ)⁻¹`) or **estimated** (`vcov = σ̂² (JᵀWJ)⁻¹`).
+* `vcov(fit)` is a parameter **covariance** matrix; `stderror(fit)` is its
+  diagonal **standard deviations**.
+
+## Standard deviation vs variance vs covariance
+
+These three live in different units and play different roles. Keeping them
+straight removes essentially all the ambiguity.
+
+| Quantity | Symbol | Units | Where it appears in LsqFit |
+|:---------|:-------|:------|:---------------------------|
+| Standard deviation of observation `i` | `σᵢ` | same as `yᵢ` | *not* passed directly |
+| Variance of observation `i` | `σᵢ²` | `yᵢ²` | a **vector** weight is `1/σᵢ²` |
+| Covariance of observations | `Σ` | `yᵢ yⱼ` | a **matrix** weight is `Σ⁻¹` |
+| Covariance of parameters | `Cov(γ̂)` | `pᵢ pⱼ` | `vcov(fit)` |
+| Standard error of parameter `k` | `√Cov(γ̂)ₖₖ` | same as `pₖ` | `stderror(fit)` |
+
+So the data uncertainties go **in** as inverse variances, and the parameter
+uncertainties come **out** as a covariance matrix whose square-rooted diagonal
+are the standard errors.
+
+!!! warning "Inverse variance, not inverse standard deviation"
+    If observation `i` has standard deviation `σᵢ`, its weight is `1/σᵢ²`. A
+    common mistake is to pass `1/σᵢ`. The reason `1/σᵢ²` is correct: the weight
+    multiplies the **squared** residual, `∑ wᵢ (model−y)ᵢ²`, and the optimal
+    (minimum-variance) weighting of a squared residual is the inverse of its
+    variance.
+
+## The math
+
+Near the optimum the weighted problem linearises to
+
+```math
+\hat{\boldsymbol{h}} = \hat{\boldsymbol{γ}} - \boldsymbol{γ}^*
+    \approx -[J'WJ]^{-1} J' W \boldsymbol{r},
+```
+
+where `J` is the Jacobian of the model and `W` the weight matrix. With errors
+`ε ∼ N(0, Σ)` and the optimal weights `W = Σ⁻¹`, the parameter covariance is
+
+```math
+\mathbf{Cov}(\boldsymbol{γ}^*)
+    = [J'WJ]^{-1} J'W\,\Sigma\,W'J\,[J'W'J]^{-1}
+    = [J'WJ]^{-1}.
+```
+
+This is the **known-variance** case: you supplied the exact `Σ⁻¹`, so there is
+no scale left to estimate.
+
+If instead you only know the variances **up to a common unknown factor**,
+`ε ∼ N(0, σ² W⁻¹)`, then
+
+```math
+\mathbf{Cov}(\boldsymbol{γ}^*) = σ^2 [J'WJ]^{-1},
+```
+
+and `σ²` is **estimated** from the residuals as `σ̂² = `RSS`/(n-p)` (the mean
+squared error, [`LsqFit.mse`](@ref)). Because the same `σ²` multiplies the whole
+matrix, this estimator is **scale-invariant**: multiplying every weight by a
+constant does not change `vcov`.
+
+Both formulas are correct — they answer different questions. The unweighted fit
+is the special case `W = I` of the second formula.
+
+## How `wt` selects the formula
+
+LsqFit picks the formula from the **type** of `wt`. The values are the same
+inverse variances in every row below.
+
+| `wt` argument | scale `σ²` | `vcov(fit)` | `nobs` |
+|:--------------|:-----------|:------------|:-------|
+| *omitted* | estimated | `σ̂² (JᵀJ)⁻¹` | `n` |
+| `1 ./ σ.^2` (bare `Vector`) | **known** (`≡1`) | `(JᵀWJ)⁻¹` | `n` |
+| `inv(Σ)` (`Matrix`) | **known** (`≡1`) | `(JᵀWJ)⁻¹` | `n` |
+| [`AnalyticWeights`](@ref)`(1 ./ σ.^2)` | estimated | `σ̂² (JᵀWJ)⁻¹` | `n` |
+| [`FrequencyWeights`](@ref)`(counts)` | estimated | `σ̂² (JᵀWJ)⁻¹` | `∑w` |
+
+The weight types are re-exported from
+[StatsBase](https://juliastats.org/StatsBase.jl/stable/weights/) and keep their
+StatsBase meaning:
+
+* **`AnalyticWeights`** — *reliability / precision / inverse-variance* weights.
+  They describe a **relative** importance, so the common scale is estimated and
+  the result is scale-invariant. This matches MATLAB `nlinfit`, Origin and
+  LabPlot.
+* **`FrequencyWeights`** — integer **counts**: weight `wᵢ` means observation `i`
+  was seen `wᵢ` times. Here `nobs = ∑w`, so more counts means more information
+  and tighter intervals.
+* A **bare vector / matrix** asserts the weights are the *exact* inverse
+  (co)variance and the scale is therefore known.
+
+!!! note "Unsupported weight types"
+    `ProbabilityWeights` (sampling weights) require a sandwich/survey variance,
+    and a generic `Weights` carries no covariance semantics (StatsBase itself
+    refuses a bias correction for it). LsqFit therefore throws an informative
+    error rather than return a silently wrong covariance.
+
+## Worked example (issue #255)
+
+This is the dataset from the discussion that motivated the typed weights. We fit
+`f(x) = A·exp(B·x)` with 5 % relative measurement error.
+
+```@example weights
+using LsqFit
+
+model(x, p) = p[1] .* exp.(p[2] .* x)
+
+x = Float64[1, 2, 4, 5, 8]
+y = Float64[3, 4, 6, 11, 20]
+σ = 0.05 .* y          # known standard deviations
+wt = 1 ./ σ.^2         # inverse variances
+
+nothing # hide
+```
+
+Treating the weights as **exact** inverse variances (bare vector, scale known):
+
+```@example weights
+fit_known = curve_fit(model, x, y, wt, [2.0, 0.3])
+coef(fit_known), stderror(fit_known)
+```
+
+Treating them as **relative** precisions and estimating the scale
+(`AnalyticWeights`):
+
+```@example weights
+fit_rel = curve_fit(model, x, y, AnalyticWeights(wt), [2.0, 0.3])
+coef(fit_rel), stderror(fit_rel)
+```
+
+The point estimates are identical (`A ≈ 2.263`, `B ≈ 0.275`); only the standard
+errors differ. The bare-vector errors are about `±0.097` / `±0.009`, while the
+`AnalyticWeights` errors are about `±0.258` / `±0.024` — the latter reproduce the
+values reported by Origin/LabPlot/mycurvefit for the same data. Neither is a
+bug: they answer "what is the uncertainty *given the known noise*?" versus "what
+is the uncertainty *if the noise level is itself estimated*?".
+
+### Scale invariance
+
+`AnalyticWeights` describe relative precision, so the overall scale cancels:
+
+```@example weights
+se1 = stderror(curve_fit(model, x, y, AnalyticWeights(wt), [2.0, 0.3]))
+se2 = stderror(curve_fit(model, x, y, AnalyticWeights(10 .* wt), [2.0, 0.3]))
+se1 ≈ se2
+```
+
+A bare vector is **not** scale-invariant (multiplying it changes the asserted
+variances), and `AnalyticWeights(ones(n))` reproduces the unweighted fit while a
+bare vector of ones does not.
+
+### Frequency weights
+
+If each row is really a repeated measurement, use `FrequencyWeights`; `nobs`
+becomes the total count:
+
+```@example weights
+fit_freq = curve_fit(model, x, y, FrequencyWeights([3, 1, 1, 2, 1]), [2.0, 0.3])
+nobs(fit_freq), dof(fit_freq)
+```
+
+## Monte-Carlo coverage check
+
+The honest test of an uncertainty estimate is its **coverage**: across many
+simulated datasets, a 95 % confidence interval should contain the true parameter
+about 95 % of the time. We simulate from a known model with known heteroscedastic
+noise and use [`confint`](@ref) (a Student-t interval) for each fit.
+
+```@example weights
+using Random
+
+truth = [2.0, 0.25]
+xg = collect(range(0.5, 6; length = 15))
+rng = MersenneTwister(20240617)
+N = 4000
+
+covers(lohi, t) = [lo <= t <= hi for ((lo, hi), t) in zip(lohi, (t[1], t[2]))]
+
+hitK = zeros(2); hitA = zeros(2); hitU = zeros(2)
+for _ in 1:N
+    sd = 0.10 .* model(xg, truth)               # known standard deviations
+    yg = model(xg, truth) .+ sd .* randn(rng, length(xg))
+    w  = 1 ./ sd.^2
+    fK = curve_fit(model, xg, yg, w, copy(truth))                   # known variance
+    fA = curve_fit(model, xg, yg, AnalyticWeights(w), copy(truth))  # estimate scale
+    fU = curve_fit(model, xg, yg, copy(truth))                      # unweighted (wrong)
+    global hitK += covers(confint(fK; level = 0.95), truth)
+    global hitA += covers(confint(fA; level = 0.95), truth)
+    global hitU += covers(confint(fU; level = 0.95), truth)
+end
+(known = round.(100 .* hitK ./ N; digits = 1),
+ analytic = round.(100 .* hitA ./ N; digits = 1),
+ unweighted = round.(100 .* hitU ./ N; digits = 1))
+```
+
+At larger `N` (30 000 in our reference run) the coverages settle to roughly:
+
+| 95 % CIs | A | B |
+|:---------|:--|:--|
+| bare vector (known variance) | ≈ 95 % | ≈ 95 % |
+| `AnalyticWeights` (estimate scale) | ≈ 95 % | ≈ 95 % |
+| unweighted (ignores heteroscedasticity) | mis-calibrated | mis-calibrated |
+
+Reading the table:
+
+* **Both weighted interpretations hit the nominal 95 %.** They differ only in the
+  reference distribution LsqFit uses for the interval, and each uses the correct
+  one for its assumption:
+  * `AnalyticWeights` **estimate** the scale, so `(γ̂ₖ − γₖ)/seₖ` follows
+    Student-t with `dof = n − p`; [`confint`](@ref) uses Student-t and the
+    interval is calibrated.
+  * A bare vector treats the variance as **known**, so the same ratio is
+    asymptotically standard normal; [`confint`](@ref) uses the normal
+    (asymptotic) quantile `z` here. Using Student-t instead would inflate the
+    interval by `t(n−p)/z` (here `2.16/1.96 ≈ 1.10`) and over-cover at ≈ 97 %,
+    which is why the normal quantile is the right choice when σ² is supplied.
+* **Ignoring the known heteroscedasticity is mis-calibrated.** This is the case
+  that is actually "wrong" — not the choice between the two weighted formulas.
+
+!!! note "Which quantile LsqFit uses"
+    `margin_error`/`confint` pick the reference distribution from the weight type:
+    Student-t (`dof = n − p`) when the scale is estimated (unweighted,
+    `AnalyticWeights`, `FrequencyWeights`) and the standard normal when the scale
+    is known (bare vector or inverse-covariance matrix).
+
+This is the empirical version of the conclusion reached in the issue discussion:
+*both* weighted interpretations are valid; what matters is matching the
+interpretation to what you actually know about the noise.
+
+## Choosing a weight type
+
+* You know each `σᵢ` (e.g. instrument error bars) and trust them as absolute →
+  **bare vector `1 ./ σ.^2`** (or `inv(Σ)` for correlated errors).
+* You know only the *relative* precision of points, or you want results
+  consistent with MATLAB/Origin/LabPlot → **`AnalyticWeights(1 ./ σ.^2)`**.
+* Each row is a repeated/aggregated count → **`FrequencyWeights(counts)`**.
+* You have nothing better → leave `wt` out (unweighted, scale estimated).

--- a/docs/src/weights.md
+++ b/docs/src/weights.md
@@ -1,45 +1,36 @@
 # Weights
 
-Weighted least squares is where most of the confusion about LsqFit's uncertainty
-estimates comes from. This page makes the roles of **standard deviation**,
-**variance** and **covariance** explicit, derives the two covariance formulas,
-shows them on a worked example, and finally *verifies* them with a Monte-Carlo
-coverage study so you can trust the numbers rather than take them on faith.
+This page describes how weighted fits affect the reported parameter
+uncertainties, how the weight values and weight types are interpreted, and a
+Monte-Carlo check of the resulting confidence intervals.
 
-The short version:
+Two points cover most of the confusion around weighted fits:
 
-* The weight **values** you pass are always **inverse variances**
-  (`wᵢ = 1/σᵢ²`), never standard deviations.
-* The weight **type** decides whether the overall noise scale `σ²` is treated as
-  **known** (`vcov = (JᵀWJ)⁻¹`) or **estimated** (`vcov = σ̂² (JᵀWJ)⁻¹`).
-* `vcov(fit)` is a parameter **covariance** matrix; `stderror(fit)` is its
-  diagonal **standard deviations**.
+* The weight *values* are inverse variances (`wᵢ = 1/σᵢ²`), not standard
+  deviations.
+* The weight *type* decides whether the noise scale `σ²` is treated as known or
+  estimated. `vcov(fit)` returns a parameter covariance matrix and
+  `stderror(fit)` the square root of its diagonal.
 
-## Standard deviation vs variance vs covariance
+## Standard deviation, variance and covariance
 
-These three live in different units and play different roles. Keeping them
-straight removes essentially all the ambiguity.
+| Quantity | Symbol | Units | Role |
+|:---------|:-------|:------|:-----|
+| Observation standard deviation | `σᵢ` | like `yᵢ` | not passed directly |
+| Observation variance | `σᵢ²` | `yᵢ²` | a vector weight is `1/σᵢ²` |
+| Observation covariance | `Σ` | `yᵢ yⱼ` | a matrix weight is `Σ⁻¹` |
+| Parameter covariance | `Cov(γ̂)` | `pᵢ pⱼ` | `vcov(fit)` |
+| Parameter standard error | `√Cov(γ̂)ₖₖ` | like `pₖ` | `stderror(fit)` |
 
-| Quantity | Symbol | Units | Where it appears in LsqFit |
-|:---------|:-------|:------|:---------------------------|
-| Standard deviation of observation `i` | `σᵢ` | same as `yᵢ` | *not* passed directly |
-| Variance of observation `i` | `σᵢ²` | `yᵢ²` | a **vector** weight is `1/σᵢ²` |
-| Covariance of observations | `Σ` | `yᵢ yⱼ` | a **matrix** weight is `Σ⁻¹` |
-| Covariance of parameters | `Cov(γ̂)` | `pᵢ pⱼ` | `vcov(fit)` |
-| Standard error of parameter `k` | `√Cov(γ̂)ₖₖ` | same as `pₖ` | `stderror(fit)` |
+The data uncertainties go in as inverse variances and the parameter
+uncertainties come out as a covariance matrix whose square-rooted diagonal gives
+the standard errors.
 
-So the data uncertainties go **in** as inverse variances, and the parameter
-uncertainties come **out** as a covariance matrix whose square-rooted diagonal
-are the standard errors.
+If observation `i` has standard deviation `σᵢ`, its weight is `1/σᵢ²`, not
+`1/σᵢ`. The weight multiplies the squared residual `∑ wᵢ (model−y)ᵢ²`, and the
+minimum-variance weighting of a squared residual is the inverse of its variance.
 
-!!! warning "Inverse variance, not inverse standard deviation"
-    If observation `i` has standard deviation `σᵢ`, its weight is `1/σᵢ²`. A
-    common mistake is to pass `1/σᵢ`. The reason `1/σᵢ²` is correct: the weight
-    multiplies the **squared** residual, `∑ wᵢ (model−y)ᵢ²`, and the optimal
-    (minimum-variance) weighting of a squared residual is the inverse of its
-    variance.
-
-## The math
+## Weighted least squares
 
 Near the optimum the weighted problem linearises to
 
@@ -48,8 +39,8 @@ Near the optimum the weighted problem linearises to
     \approx -[J'WJ]^{-1} J' W \boldsymbol{r},
 ```
 
-where `J` is the Jacobian of the model and `W` the weight matrix. With errors
-`ε ∼ N(0, Σ)` and the optimal weights `W = Σ⁻¹`, the parameter covariance is
+with `J` the Jacobian and `W` the weight matrix. For errors `ε ∼ N(0, Σ)` and
+the optimal weights `W = Σ⁻¹`,
 
 ```math
 \mathbf{Cov}(\boldsymbol{γ}^*)
@@ -57,61 +48,57 @@ where `J` is the Jacobian of the model and `W` the weight matrix. With errors
     = [J'WJ]^{-1}.
 ```
 
-This is the **known-variance** case: you supplied the exact `Σ⁻¹`, so there is
-no scale left to estimate.
+This is the known-variance case: the exact `Σ⁻¹` was supplied, so there is no
+scale left to estimate.
 
-If instead you only know the variances **up to a common unknown factor**,
+If the variances are known only up to a common unknown factor,
 `ε ∼ N(0, σ² W⁻¹)`, then
 
 ```math
 \mathbf{Cov}(\boldsymbol{γ}^*) = σ^2 [J'WJ]^{-1},
 ```
 
-and `σ²` is **estimated** from the residuals as `σ̂² = `RSS`/(n-p)` (the mean
-squared error, [`LsqFit.mse`](@ref)). Because the same `σ²` multiplies the whole
-matrix, this estimator is **scale-invariant**: multiplying every weight by a
-constant does not change `vcov`.
+with `σ²` estimated from the residuals as `σ̂² = `RSS`/(n-p)` ([`LsqFit.mse`](@ref)).
+The same `σ²` multiplies the whole matrix, so this estimator does not change if
+all weights are multiplied by a constant. The unweighted fit is the case `W = I`
+of this second formula.
 
-Both formulas are correct — they answer different questions. The unweighted fit
-is the special case `W = I` of the second formula.
+Both formulas are correct; they answer different questions.
 
-## How `wt` selects the formula
+## Weight types
 
-LsqFit picks the formula from the **type** of `wt`. The values are the same
-inverse variances in every row below.
+LsqFit selects the formula from the type of `wt`. The values are the same
+inverse variances in every case.
 
 | `wt` argument | scale `σ²` | `vcov(fit)` | `nobs` |
 |:--------------|:-----------|:------------|:-------|
-| *omitted* | estimated | `σ̂² (JᵀJ)⁻¹` | `n` |
-| `1 ./ σ.^2` (bare `Vector`) | **known** (`≡1`) | `(JᵀWJ)⁻¹` | `n` |
-| `inv(Σ)` (`Matrix`) | **known** (`≡1`) | `(JᵀWJ)⁻¹` | `n` |
+| omitted | estimated | `σ̂² (JᵀJ)⁻¹` | `n` |
+| `1 ./ σ.^2` (`Vector`) | known | `(JᵀWJ)⁻¹` | `n` |
+| `inv(Σ)` (`Matrix`) | known | `(JᵀWJ)⁻¹` | `n` |
 | [`AnalyticWeights`](@ref)`(1 ./ σ.^2)` | estimated | `σ̂² (JᵀWJ)⁻¹` | `n` |
 | [`FrequencyWeights`](@ref)`(counts)` | estimated | `σ̂² (JᵀWJ)⁻¹` | `∑w` |
 
-The weight types are re-exported from
+The typed weights are re-exported from
 [StatsBase](https://juliastats.org/StatsBase.jl/stable/weights/) and keep their
 StatsBase meaning:
 
-* **`AnalyticWeights`** — *reliability / precision / inverse-variance* weights.
-  They describe a **relative** importance, so the common scale is estimated and
-  the result is scale-invariant. This matches MATLAB `nlinfit`, Origin and
-  LabPlot.
-* **`FrequencyWeights`** — integer **counts**: weight `wᵢ` means observation `i`
-  was seen `wᵢ` times. Here `nobs = ∑w`, so more counts means more information
-  and tighter intervals.
-* A **bare vector / matrix** asserts the weights are the *exact* inverse
-  (co)variance and the scale is therefore known.
+* `AnalyticWeights` are reliability or inverse-variance weights. They give a
+  relative importance, so the common scale is estimated and the result does not
+  depend on the overall magnitude of the weights. This is the convention used by
+  MATLAB `nlinfit`, Origin and LabPlot.
+* `FrequencyWeights` are integer counts: `wᵢ` means observation `i` was seen `wᵢ`
+  times, so `nobs = ∑w`.
+* A bare vector or matrix is taken as the exact inverse (co)variance, so the
+  scale is known.
 
-!!! note "Unsupported weight types"
-    `ProbabilityWeights` (sampling weights) require a sandwich/survey variance,
-    and a generic `Weights` carries no covariance semantics (StatsBase itself
-    refuses a bias correction for it). LsqFit therefore throws an informative
-    error rather than return a silently wrong covariance.
+`ProbabilityWeights` would require a survey/sandwich variance, and a generic
+`Weights` has no associated bias correction in StatsBase. Passing either throws
+an error rather than returning a covariance that does not match the type.
 
-## Worked example (issue #255)
+## Example
 
-This is the dataset from the discussion that motivated the typed weights. We fit
-`f(x) = A·exp(B·x)` with 5 % relative measurement error.
+The dataset below is the one from issue #255. The model is `f(x) = A·exp(B·x)`
+with a 5 % relative measurement error.
 
 ```@example weights
 using LsqFit
@@ -120,37 +107,32 @@ model(x, p) = p[1] .* exp.(p[2] .* x)
 
 x = Float64[1, 2, 4, 5, 8]
 y = Float64[3, 4, 6, 11, 20]
-σ = 0.05 .* y          # known standard deviations
+σ = 0.05 .* y          # standard deviations
 wt = 1 ./ σ.^2         # inverse variances
 
 nothing # hide
 ```
 
-Treating the weights as **exact** inverse variances (bare vector, scale known):
+Taking the weights as exact inverse variances (bare vector, known scale):
 
 ```@example weights
 fit_known = curve_fit(model, x, y, wt, [2.0, 0.3])
 coef(fit_known), stderror(fit_known)
 ```
 
-Treating them as **relative** precisions and estimating the scale
-(`AnalyticWeights`):
+Taking them as relative precisions and estimating the scale:
 
 ```@example weights
 fit_rel = curve_fit(model, x, y, AnalyticWeights(wt), [2.0, 0.3])
 coef(fit_rel), stderror(fit_rel)
 ```
 
-The point estimates are identical (`A ≈ 2.263`, `B ≈ 0.275`); only the standard
-errors differ. The bare-vector errors are about `±0.097` / `±0.009`, while the
-`AnalyticWeights` errors are about `±0.258` / `±0.024` — the latter reproduce the
-values reported by Origin/LabPlot/mycurvefit for the same data. Neither is a
-bug: they answer "what is the uncertainty *given the known noise*?" versus "what
-is the uncertainty *if the noise level is itself estimated*?".
+The point estimates agree (`A ≈ 2.263`, `B ≈ 0.275`); only the standard errors
+differ. The bare-vector errors are about `±0.097` / `±0.009`, the
+`AnalyticWeights` errors about `±0.258` / `±0.024`. The latter match the values
+reported by Origin, LabPlot and mycurvefit for this data.
 
-### Scale invariance
-
-`AnalyticWeights` describe relative precision, so the overall scale cancels:
+`AnalyticWeights` do not depend on the overall scale of the weights:
 
 ```@example weights
 se1 = stderror(curve_fit(model, x, y, AnalyticWeights(wt), [2.0, 0.3]))
@@ -158,26 +140,21 @@ se2 = stderror(curve_fit(model, x, y, AnalyticWeights(10 .* wt), [2.0, 0.3]))
 se1 ≈ se2
 ```
 
-A bare vector is **not** scale-invariant (multiplying it changes the asserted
-variances), and `AnalyticWeights(ones(n))` reproduces the unweighted fit while a
-bare vector of ones does not.
+A bare vector does depend on the scale, and `AnalyticWeights(ones(n))` reproduces
+the unweighted fit while a bare vector of ones does not.
 
-### Frequency weights
-
-If each row is really a repeated measurement, use `FrequencyWeights`; `nobs`
-becomes the total count:
+For repeated measurements use `FrequencyWeights`; `nobs` is then the total count:
 
 ```@example weights
 fit_freq = curve_fit(model, x, y, FrequencyWeights([3, 1, 1, 2, 1]), [2.0, 0.3])
 nobs(fit_freq), dof(fit_freq)
 ```
 
-## Monte-Carlo coverage check
+## Monte-Carlo coverage
 
-The honest test of an uncertainty estimate is its **coverage**: across many
-simulated datasets, a 95 % confidence interval should contain the true parameter
-about 95 % of the time. We simulate from a known model with known heteroscedastic
-noise and use [`confint`](@ref) (a Student-t interval) for each fit.
+A 95 % confidence interval should contain the true parameter about 95 % of the
+time. The following simulates from a known model with known heteroscedastic
+noise and counts how often [`confint`](@ref) covers the truth.
 
 ```@example weights
 using Random
@@ -191,12 +168,12 @@ covers(lohi, t) = [lo <= t <= hi for ((lo, hi), t) in zip(lohi, (t[1], t[2]))]
 
 hitK = zeros(2); hitA = zeros(2); hitU = zeros(2)
 for _ in 1:N
-    sd = 0.10 .* model(xg, truth)               # known standard deviations
+    sd = 0.10 .* model(xg, truth)
     yg = model(xg, truth) .+ sd .* randn(rng, length(xg))
     w  = 1 ./ sd.^2
     fK = curve_fit(model, xg, yg, w, copy(truth))                   # known variance
     fA = curve_fit(model, xg, yg, AnalyticWeights(w), copy(truth))  # estimate scale
-    fU = curve_fit(model, xg, yg, copy(truth))                      # unweighted (wrong)
+    fU = curve_fit(model, xg, yg, copy(truth))                      # unweighted
     global hitK += covers(confint(fK; level = 0.95), truth)
     global hitA += covers(confint(fA; level = 0.95), truth)
     global hitU += covers(confint(fU; level = 0.95), truth)
@@ -206,47 +183,31 @@ end
  unweighted = round.(100 .* hitU ./ N; digits = 1))
 ```
 
-At larger `N` (30 000 in our reference run) the coverages settle to roughly:
+At `N = 30 000` the coverages are about:
 
 | 95 % CIs | A | B |
 |:---------|:--|:--|
-| bare vector (known variance) | ≈ 97 % | ≈ 97 % |
-| `AnalyticWeights` (estimate scale) | ≈ 95 % | ≈ 95 % |
+| bare vector (known variance) | 97 % | 97 % |
+| `AnalyticWeights` (estimate scale) | 95 % | 95 % |
 | unweighted (ignores heteroscedasticity) | mis-calibrated | mis-calibrated |
 
-Reading the table:
+`AnalyticWeights` estimate the scale, so `(γ̂ₖ − γₖ)/seₖ` follows Student-t with
+`dof = n − p` and the interval is calibrated. With a known variance the correct
+multiplier is the normal `z = 1.96`, but for backwards compatibility `confint`
+keeps the Student-t reference (`t(13) = 2.16`) for a bare vector, which widens
+the interval by about 10 % and raises coverage to 97 %. The standard errors are
+unchanged; using the normal quantile recovers 95 %. Ignoring known
+heteroscedasticity is the case that is actually wrong.
 
-* **`AnalyticWeights` hit the nominal 95 % almost exactly.** The scale is
-  estimated, so `(γ̂ₖ − γₖ)/seₖ` follows Student-t with `dof = n − p`;
-  [`confint`](@ref) uses Student-t and the interval is calibrated.
-* **The bare vector slightly over-covers — and the cause is the interval
-  multiplier, not the covariance.** When the variance is genuinely known there is
-  no estimated scale, so the asymptotically-correct multiplier is the normal
-  `z = 1.96`. For backwards compatibility [`confint`](@ref) keeps the Student-t
-  reference (`t(n−p) = 2.16` here) for a bare vector, inflating the interval by
-  `t/z ≈ 1.10` and lifting coverage to ≈ 97 %. This is mildly **conservative**
-  (never anti-conservative). The standard errors themselves are exact: swapping
-  in the normal quantile recovers 95 % precisely.
-* **Ignoring the known heteroscedasticity is mis-calibrated.** This is the case
-  that is actually "wrong" — not the choice between the two weighted formulas.
+`margin_error` and `confint` use Student-t for the unweighted case and for
+untyped inputs (a bare vector or a matrix). Typed `AbstractWeights` use Student-t
+when the scale is estimated and the normal quantile when it is known.
 
-!!! note "Which quantile LsqFit uses"
-    `margin_error`/`confint` use Student-t (`dof = n − p`) for the unweighted case
-    and for untyped weight inputs (a bare vector or an inverse-covariance matrix),
-    preserving historical behaviour. Typed `AbstractWeights` select the
-    asymptotically-correct reference instead: Student-t when the scale is
-    estimated (`AnalyticWeights`, `FrequencyWeights`) and the standard normal when
-    it is known.
+## Choosing weights
 
-This is the empirical version of the conclusion reached in the issue discussion:
-*both* weighted interpretations are valid; what matters is matching the
-interpretation to what you actually know about the noise.
-
-## Choosing a weight type
-
-* You know each `σᵢ` (e.g. instrument error bars) and trust them as absolute →
-  **bare vector `1 ./ σ.^2`** (or `inv(Σ)` for correlated errors).
-* You know only the *relative* precision of points, or you want results
-  consistent with MATLAB/Origin/LabPlot → **`AnalyticWeights(1 ./ σ.^2)`**.
-* Each row is a repeated/aggregated count → **`FrequencyWeights(counts)`**.
-* You have nothing better → leave `wt` out (unweighted, scale estimated).
+* Known `σᵢ`, trusted as absolute: bare vector `1 ./ σ.^2`, or `inv(Σ)` for
+  correlated errors.
+* Only relative precisions known, or results that match MATLAB/Origin/LabPlot:
+  `AnalyticWeights(1 ./ σ.^2)`.
+* Repeated or aggregated counts: `FrequencyWeights(counts)`.
+* Nothing better: leave `wt` out.

--- a/docs/src/weights.md
+++ b/docs/src/weights.md
@@ -210,31 +210,33 @@ At larger `N` (30 000 in our reference run) the coverages settle to roughly:
 
 | 95 % CIs | A | B |
 |:---------|:--|:--|
-| bare vector (known variance) | ≈ 95 % | ≈ 95 % |
+| bare vector (known variance) | ≈ 97 % | ≈ 97 % |
 | `AnalyticWeights` (estimate scale) | ≈ 95 % | ≈ 95 % |
 | unweighted (ignores heteroscedasticity) | mis-calibrated | mis-calibrated |
 
 Reading the table:
 
-* **Both weighted interpretations hit the nominal 95 %.** They differ only in the
-  reference distribution LsqFit uses for the interval, and each uses the correct
-  one for its assumption:
-  * `AnalyticWeights` **estimate** the scale, so `(γ̂ₖ − γₖ)/seₖ` follows
-    Student-t with `dof = n − p`; [`confint`](@ref) uses Student-t and the
-    interval is calibrated.
-  * A bare vector treats the variance as **known**, so the same ratio is
-    asymptotically standard normal; [`confint`](@ref) uses the normal
-    (asymptotic) quantile `z` here. Using Student-t instead would inflate the
-    interval by `t(n−p)/z` (here `2.16/1.96 ≈ 1.10`) and over-cover at ≈ 97 %,
-    which is why the normal quantile is the right choice when σ² is supplied.
+* **`AnalyticWeights` hit the nominal 95 % almost exactly.** The scale is
+  estimated, so `(γ̂ₖ − γₖ)/seₖ` follows Student-t with `dof = n − p`;
+  [`confint`](@ref) uses Student-t and the interval is calibrated.
+* **The bare vector slightly over-covers — and the cause is the interval
+  multiplier, not the covariance.** When the variance is genuinely known there is
+  no estimated scale, so the asymptotically-correct multiplier is the normal
+  `z = 1.96`. For backwards compatibility [`confint`](@ref) keeps the Student-t
+  reference (`t(n−p) = 2.16` here) for a bare vector, inflating the interval by
+  `t/z ≈ 1.10` and lifting coverage to ≈ 97 %. This is mildly **conservative**
+  (never anti-conservative). The standard errors themselves are exact: swapping
+  in the normal quantile recovers 95 % precisely.
 * **Ignoring the known heteroscedasticity is mis-calibrated.** This is the case
   that is actually "wrong" — not the choice between the two weighted formulas.
 
 !!! note "Which quantile LsqFit uses"
-    `margin_error`/`confint` pick the reference distribution from the weight type:
-    Student-t (`dof = n − p`) when the scale is estimated (unweighted,
-    `AnalyticWeights`, `FrequencyWeights`) and the standard normal when the scale
-    is known (bare vector or inverse-covariance matrix).
+    `margin_error`/`confint` use Student-t (`dof = n − p`) for the unweighted case
+    and for untyped weight inputs (a bare vector or an inverse-covariance matrix),
+    preserving historical behaviour. Typed `AbstractWeights` select the
+    asymptotically-correct reference instead: Student-t when the scale is
+    estimated (`AnalyticWeights`, `FrequencyWeights`) and the standard normal when
+    it is known.
 
 This is the empirical version of the conclusion reached in the issue discussion:
 *both* weighted interpretations are valid; what matters is matching the

--- a/docs/src/weights.md
+++ b/docs/src/weights.md
@@ -74,12 +74,17 @@ inverse variances in every case.
 | `wt` argument | scale `σ²` | `vcov(fit)` | `nobs` |
 |:--------------|:-----------|:------------|:-------|
 | omitted | estimated | `σ̂² (JᵀJ)⁻¹` | `n` |
-| `1 ./ σ.^2` (`Vector`) | known | `(JᵀWJ)⁻¹` | `n` |
-| `inv(Σ)` (`Matrix`) | known | `(JᵀWJ)⁻¹` | `n` |
 | [`PrecisionWeights`](@ref)`(1 ./ σ.^2)` | known | `(JᵀWJ)⁻¹` | `n` |
 | [`PrecisionMatrix`](@ref)`(inv(Σ))` | known | `(JᵀWJ)⁻¹` | `n` |
 | `AnalyticWeights(1 ./ σ.^2)` | estimated | `σ̂² (JᵀWJ)⁻¹` | `n` |
 | `FrequencyWeights(counts)` | estimated | `σ̂² (JᵀWJ)⁻¹` | `∑w` |
+
+!!! warning "Deprecated: bare vector and matrix weights"
+    Passing a bare `1 ./ σ.^2` vector or `inv(Σ)` matrix is deprecated and emits a
+    warning. Wrap them in [`PrecisionWeights`](@ref) / [`PrecisionMatrix`](@ref)
+    for the same known-variance covariance (with the calibrated normal interval),
+    or in `AnalyticWeights` to estimate the scale. The bare forms previously kept a
+    Student-t interval purely for backwards compatibility.
 
 `AnalyticWeights`, `FrequencyWeights` are re-exported from
 [StatsBase](https://juliastats.org/StatsBase.jl/stable/weights/) and keep their
@@ -96,9 +101,9 @@ StatsBase meaning; `PrecisionWeights` and `PrecisionMatrix` are defined by LsqFi
   MATLAB `nlinfit`, Origin and LabPlot.
 * `FrequencyWeights` are integer counts: `wᵢ` means observation `i` was seen `wᵢ`
   times, so `nobs = ∑w`.
-* A bare vector or matrix is taken as the exact inverse (co)variance, like
-  `PrecisionWeights`/`PrecisionMatrix`, but keeps the Student-t interval for
-  backwards compatibility.
+* A bare vector or matrix (deprecated) is taken as the exact inverse (co)variance,
+  like `PrecisionWeights`/`PrecisionMatrix`, but keeps the Student-t interval for
+  backwards compatibility. Prefer the typed forms.
 
 StatsBase has no weight type for the known-variance case (all of its corrected
 weights estimate the scale), which is why `PrecisionWeights`/`PrecisionMatrix`
@@ -125,10 +130,10 @@ wt = 1 ./ σ.^2         # inverse variances
 nothing # hide
 ```
 
-Taking the weights as exact inverse variances (bare vector, known scale):
+Taking the weights as exact inverse variances (known scale):
 
 ```@example weights
-fit_known = curve_fit(model, x, y, wt, [2.0, 0.3])
+fit_known = curve_fit(model, x, y, PrecisionWeights(wt), [2.0, 0.3])
 coef(fit_known), stderror(fit_known)
 ```
 
@@ -140,8 +145,8 @@ coef(fit_rel), stderror(fit_rel)
 ```
 
 The point estimates agree (`A ≈ 2.263`, `B ≈ 0.275`); only the standard errors
-differ. The bare-vector errors are about `±0.097` / `±0.009`, the
-`AnalyticWeights` errors about `±0.258` / `±0.024`. The latter match the values
+differ. The known-scale (`PrecisionWeights`) errors are about `±0.097` / `±0.009`,
+the `AnalyticWeights` errors about `±0.258` / `±0.024`. The latter match the values
 reported by Origin, LabPlot and mycurvefit for this data.
 
 `AnalyticWeights` do not depend on the overall scale of the weights:
@@ -152,8 +157,8 @@ se2 = stderror(curve_fit(model, x, y, AnalyticWeights(10 .* wt), [2.0, 0.3]))
 se1 ≈ se2
 ```
 
-A bare vector does depend on the scale, and `AnalyticWeights(ones(n))` reproduces
-the unweighted fit while a bare vector of ones does not.
+`PrecisionWeights` do depend on the scale, and `AnalyticWeights(ones(n))`
+reproduces the unweighted fit while `PrecisionWeights(ones(n))` does not.
 
 For repeated measurements use `FrequencyWeights`; `nobs` is then the total count:
 
@@ -178,17 +183,15 @@ N = 4000
 
 covers(lohi, t) = [lo <= t <= hi for ((lo, hi), t) in zip(lohi, (t[1], t[2]))]
 
-hitV = zeros(2); hitK = zeros(2); hitA = zeros(2); hitU = zeros(2)
+hitV = zeros(2); hitA = zeros(2); hitU = zeros(2)
 for _ in 1:N
     sd = 0.10 .* model(xg, truth)
     yg = model(xg, truth) .+ sd .* randn(rng, length(xg))
     w  = 1 ./ sd.^2
     fV = curve_fit(model, xg, yg, PrecisionWeights(w), copy(truth))  # known variance, normal CI
-    fK = curve_fit(model, xg, yg, w, copy(truth))                   # known variance, Student-t CI
     fA = curve_fit(model, xg, yg, AnalyticWeights(w), copy(truth))  # estimated scale
     fU = curve_fit(model, xg, yg, copy(truth))                      # unweighted
     global hitV += covers(confint(fV; level = 0.95), truth)
-    global hitK += covers(confint(fK; level = 0.95), truth)
     global hitA += covers(confint(fA; level = 0.95), truth)
     global hitU += covers(confint(fU; level = 0.95), truth)
 end
@@ -203,7 +206,6 @@ covrow(name, h) = [Cell(name) Cell(pct(h[1])) Cell(pct(h[2]))]
 body = vcat(
     permutedims(Cell.(["weighting", "A coverage", "B coverage"]; bold = true)),
     covrow("PrecisionWeights (known σ², normal)", hitV),
-    covrow("bare vector (known σ², Student-t)", hitK),
     covrow("AnalyticWeights (estimated scale)", hitA),
     covrow("unweighted (ignores heteroscedasticity)", hitU),
 )
@@ -214,23 +216,20 @@ Table(body; header = 1)
 with the reference distribution that matches its assumption. `PrecisionWeights`
 treats the variance as known, so `(γ̂ₖ − γₖ)/seₖ` is asymptotically normal and
 `confint` uses `z = 1.96`. `AnalyticWeights` estimate the scale, so the same
-ratio follows Student-t with `dof = n − p`. A bare vector has the same covariance
-as `PrecisionWeights` but keeps the Student-t reference (`t(13) = 2.16`) for
-backwards compatibility, which widens the interval by about 10 % and lifts its
-coverage above 95 %. Ignoring the known heteroscedasticity is the case that is
-actually wrong.
+ratio follows Student-t with `dof = n − p`. Ignoring the known heteroscedasticity
+is the case that is actually wrong.
 
-`margin_error` and `confint` use Student-t for the unweighted case and for
-untyped inputs (a bare vector or a matrix). Typed weights use Student-t when the
-scale is estimated (`AnalyticWeights`, `FrequencyWeights`) and the normal
-quantile when it is known (`PrecisionWeights`). So `PrecisionWeights(1 ./ σ.^2)`
-gives the same covariance as the bare vector but the calibrated 95 % interval.
+`margin_error` and `confint` use Student-t for the unweighted case. Typed weights
+use Student-t when the scale is estimated (`AnalyticWeights`, `FrequencyWeights`)
+and the normal quantile when it is known (`PrecisionWeights`, `PrecisionMatrix`).
+A deprecated bare vector or matrix has the same covariance as `PrecisionWeights` /
+`PrecisionMatrix` but keeps the Student-t reference for backwards compatibility.
 
 ## Choosing weights
 
 * Known `σᵢ`, trusted as absolute: `PrecisionWeights(1 ./ σ.^2)`, or
-  `PrecisionMatrix(inv(Σ))` for correlated errors. The bare `1 ./ σ.^2` vector
-  and `inv(Σ)` matrix are equivalent except that their intervals keep Student-t.
+  `PrecisionMatrix(inv(Σ))` for correlated errors. (Passing a bare `1 ./ σ.^2`
+  vector or `inv(Σ)` matrix is deprecated.)
 * Only relative precisions known, or results that match MATLAB/Origin/LabPlot:
   `AnalyticWeights(1 ./ σ.^2)`.
 * Repeated or aggregated counts: `FrequencyWeights(counts)`.

--- a/docs/src/weights.md
+++ b/docs/src/weights.md
@@ -58,7 +58,8 @@ If the variances are known only up to a common unknown factor,
 \mathbf{Cov}(\boldsymbol{γ}^*) = σ^2 [J'WJ]^{-1},
 ```
 
-with `σ²` estimated from the residuals as `σ̂² = `RSS`/(n-p)` ([`LsqFit.mse`](@ref)).
+with `σ²` estimated from the residuals as the mean squared error `RSS/(n-p)`
+(`LsqFit.mse`).
 The same `σ²` multiplies the whole matrix, so this estimator does not change if
 all weights are multiplied by a constant. The unweighted fit is the case `W = I`
 of this second formula.
@@ -75,25 +76,36 @@ inverse variances in every case.
 | omitted | estimated | `σ̂² (JᵀJ)⁻¹` | `n` |
 | `1 ./ σ.^2` (`Vector`) | known | `(JᵀWJ)⁻¹` | `n` |
 | `inv(Σ)` (`Matrix`) | known | `(JᵀWJ)⁻¹` | `n` |
-| [`AnalyticWeights`](@ref)`(1 ./ σ.^2)` | estimated | `σ̂² (JᵀWJ)⁻¹` | `n` |
-| [`FrequencyWeights`](@ref)`(counts)` | estimated | `σ̂² (JᵀWJ)⁻¹` | `∑w` |
+| [`PrecisionWeights`](@ref)`(1 ./ σ.^2)` | known | `(JᵀWJ)⁻¹` | `n` |
+| [`PrecisionMatrix`](@ref)`(inv(Σ))` | known | `(JᵀWJ)⁻¹` | `n` |
+| `AnalyticWeights(1 ./ σ.^2)` | estimated | `σ̂² (JᵀWJ)⁻¹` | `n` |
+| `FrequencyWeights(counts)` | estimated | `σ̂² (JᵀWJ)⁻¹` | `∑w` |
 
-The typed weights are re-exported from
+`AnalyticWeights`, `FrequencyWeights` are re-exported from
 [StatsBase](https://juliastats.org/StatsBase.jl/stable/weights/) and keep their
-StatsBase meaning:
+StatsBase meaning; `PrecisionWeights` and `PrecisionMatrix` are defined by LsqFit.
 
+* `PrecisionWeights` are the exact, known inverse variances (independent errors)
+  and `PrecisionMatrix` the exact, known precision matrix `inv(Σ)` (correlated
+  errors). The scale is known, so `vcov` has no MSE factor and the confidence
+  interval uses the normal critical value. They are the typed forms of a bare
+  vector and a bare matrix.
 * `AnalyticWeights` are reliability or inverse-variance weights. They give a
   relative importance, so the common scale is estimated and the result does not
   depend on the overall magnitude of the weights. This is the convention used by
   MATLAB `nlinfit`, Origin and LabPlot.
 * `FrequencyWeights` are integer counts: `wᵢ` means observation `i` was seen `wᵢ`
   times, so `nobs = ∑w`.
-* A bare vector or matrix is taken as the exact inverse (co)variance, so the
-  scale is known.
+* A bare vector or matrix is taken as the exact inverse (co)variance, like
+  `PrecisionWeights`/`PrecisionMatrix`, but keeps the Student-t interval for
+  backwards compatibility.
 
-`ProbabilityWeights` would require a survey/sandwich variance, and a generic
-`Weights` has no associated bias correction in StatsBase. Passing either throws
-an error rather than returning a covariance that does not match the type.
+StatsBase has no weight type for the known-variance case (all of its corrected
+weights estimate the scale), which is why `PrecisionWeights`/`PrecisionMatrix`
+are provided here. `ProbabilityWeights` would require a survey/sandwich variance,
+and a generic `Weights` has no associated bias correction in StatsBase. Passing
+either throws an error rather than returning a covariance that does not match the
+type.
 
 ## Example
 
@@ -154,7 +166,7 @@ nobs(fit_freq), dof(fit_freq)
 
 A 95 % confidence interval should contain the true parameter about 95 % of the
 time. The following simulates from a known model with known heteroscedastic
-noise and counts how often [`confint`](@ref) covers the truth.
+noise and counts how often `confint` covers the truth.
 
 ```@example weights
 using Random
@@ -166,47 +178,59 @@ N = 4000
 
 covers(lohi, t) = [lo <= t <= hi for ((lo, hi), t) in zip(lohi, (t[1], t[2]))]
 
-hitK = zeros(2); hitA = zeros(2); hitU = zeros(2)
+hitV = zeros(2); hitK = zeros(2); hitA = zeros(2); hitU = zeros(2)
 for _ in 1:N
     sd = 0.10 .* model(xg, truth)
     yg = model(xg, truth) .+ sd .* randn(rng, length(xg))
     w  = 1 ./ sd.^2
-    fK = curve_fit(model, xg, yg, w, copy(truth))                   # known variance
-    fA = curve_fit(model, xg, yg, AnalyticWeights(w), copy(truth))  # estimate scale
+    fV = curve_fit(model, xg, yg, PrecisionWeights(w), copy(truth))  # known variance, normal CI
+    fK = curve_fit(model, xg, yg, w, copy(truth))                   # known variance, Student-t CI
+    fA = curve_fit(model, xg, yg, AnalyticWeights(w), copy(truth))  # estimated scale
     fU = curve_fit(model, xg, yg, copy(truth))                      # unweighted
+    global hitV += covers(confint(fV; level = 0.95), truth)
     global hitK += covers(confint(fK; level = 0.95), truth)
     global hitA += covers(confint(fA; level = 0.95), truth)
     global hitU += covers(confint(fU; level = 0.95), truth)
 end
-(known = round.(100 .* hitK ./ N; digits = 1),
- analytic = round.(100 .* hitA ./ N; digits = 1),
- unweighted = round.(100 .* hitU ./ N; digits = 1))
+nothing # hide
 ```
 
-At `N = 30 000` the coverages are about:
+```@example weights
+using SummaryTables
 
-| 95 % CIs | A | B |
-|:---------|:--|:--|
-| bare vector (known variance) | 97 % | 97 % |
-| `AnalyticWeights` (estimate scale) | 95 % | 95 % |
-| unweighted (ignores heteroscedasticity) | mis-calibrated | mis-calibrated |
+pct(h) = string(round(100 * h / N; digits = 1), " %")
+covrow(name, h) = [Cell(name) Cell(pct(h[1])) Cell(pct(h[2]))]
+body = vcat(
+    permutedims(Cell.(["weighting", "A coverage", "B coverage"]; bold = true)),
+    covrow("PrecisionWeights (known σ², normal)", hitV),
+    covrow("bare vector (known σ², Student-t)", hitK),
+    covrow("AnalyticWeights (estimated scale)", hitA),
+    covrow("unweighted (ignores heteroscedasticity)", hitU),
+)
+Table(body; header = 1)
+```
 
-`AnalyticWeights` estimate the scale, so `(γ̂ₖ − γₖ)/seₖ` follows Student-t with
-`dof = n − p` and the interval is calibrated. With a known variance the correct
-multiplier is the normal `z = 1.96`, but for backwards compatibility `confint`
-keeps the Student-t reference (`t(13) = 2.16`) for a bare vector, which widens
-the interval by about 10 % and raises coverage to 97 %. The standard errors are
-unchanged; using the normal quantile recovers 95 %. Ignoring known
-heteroscedasticity is the case that is actually wrong.
+`PrecisionWeights` and `AnalyticWeights` are both close to the nominal 95 %, each
+with the reference distribution that matches its assumption. `PrecisionWeights`
+treats the variance as known, so `(γ̂ₖ − γₖ)/seₖ` is asymptotically normal and
+`confint` uses `z = 1.96`. `AnalyticWeights` estimate the scale, so the same
+ratio follows Student-t with `dof = n − p`. A bare vector has the same covariance
+as `PrecisionWeights` but keeps the Student-t reference (`t(13) = 2.16`) for
+backwards compatibility, which widens the interval by about 10 % and lifts its
+coverage above 95 %. Ignoring the known heteroscedasticity is the case that is
+actually wrong.
 
 `margin_error` and `confint` use Student-t for the unweighted case and for
-untyped inputs (a bare vector or a matrix). Typed `AbstractWeights` use Student-t
-when the scale is estimated and the normal quantile when it is known.
+untyped inputs (a bare vector or a matrix). Typed weights use Student-t when the
+scale is estimated (`AnalyticWeights`, `FrequencyWeights`) and the normal
+quantile when it is known (`PrecisionWeights`). So `PrecisionWeights(1 ./ σ.^2)`
+gives the same covariance as the bare vector but the calibrated 95 % interval.
 
 ## Choosing weights
 
-* Known `σᵢ`, trusted as absolute: bare vector `1 ./ σ.^2`, or `inv(Σ)` for
-  correlated errors.
+* Known `σᵢ`, trusted as absolute: `PrecisionWeights(1 ./ σ.^2)`, or
+  `PrecisionMatrix(inv(Σ))` for correlated errors. The bare `1 ./ σ.^2` vector
+  and `inv(Σ)` matrix are equivalent except that their intervals keep Student-t.
 * Only relative precisions known, or results that match MATLAB/Origin/LabPlot:
   `AnalyticWeights(1 ./ σ.^2)`.
 * Repeated or aggregated counts: `FrequencyWeights(counts)`.

--- a/src/LsqFit.jl
+++ b/src/LsqFit.jl
@@ -17,7 +17,12 @@ export curve_fit,
     stderror,
     weights,
     residuals,
-    vcov
+    vcov,
+    # StatsBase weight-type reexports
+    AnalyticWeights,
+    FrequencyWeights,
+    ProbabilityWeights,
+    Weights
 
 using ADTypes: AbstractADType, AutoFiniteDiff, AutoForwardDiff
 using Distributions
@@ -29,6 +34,8 @@ using StatsAPI
 import NLSolversBase:
     value, value!, jacobian, jacobian!, value_jacobian!!, OnceDifferentiable
 using StatsAPI: coef, confint, dof, nobs, rss, stderror, weights, residuals, vcov
+using StatsBase:
+    AbstractWeights, AnalyticWeights, FrequencyWeights, ProbabilityWeights, Weights
 
 import Base.summary
 

--- a/src/LsqFit.jl
+++ b/src/LsqFit.jl
@@ -18,6 +18,8 @@ export curve_fit,
     weights,
     residuals,
     vcov,
+    PrecisionWeights,
+    PrecisionMatrix,
     # StatsBase weight-type reexports
     AnalyticWeights,
     FrequencyWeights,

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -205,8 +205,6 @@ The type of `wt` sets whether the residual scale `σ²` is known or estimated:
 | `wt` | scale `σ²` | `vcov(fit)` |
 |:-----|:-----------|:------------|
 | omitted | estimated | `σ̂² (JᵀJ)⁻¹` |
-| `1 ./ σ.^2` (vector) | known | `(JᵀWJ)⁻¹` |
-| `inv(Σ)` (matrix) | known | `(JᵀWJ)⁻¹` |
 | `PrecisionWeights(1 ./ σ.^2)` | known | `(JᵀWJ)⁻¹` |
 | `PrecisionMatrix(inv(Σ))` | known | `(JᵀWJ)⁻¹` |
 | `AnalyticWeights(1 ./ σ.^2)` | estimated | `σ̂² (JᵀWJ)⁻¹` |
@@ -214,13 +212,17 @@ The type of `wt` sets whether the residual scale `σ²` is known or estimated:
 
 `AnalyticWeights` are relative inverse-variance weights and do not depend on the
 overall scale of the weights, matching MATLAB `nlinfit`, Origin and LabPlot.
-`PrecisionWeights` (and a bare vector) are the exact inverse variances and
-`PrecisionMatrix` (and a bare matrix) the exact inverse covariance, with the
-scale known. The typed forms (`PrecisionWeights`, `PrecisionMatrix`) use the
-normal critical value for confidence intervals; the bare vector and matrix keep
-Student-t. `vcov(fit)` is the parameter covariance and `stderror(fit)` its
-square-rooted diagonal. The "Weights" page of the manual has the derivation and a
-coverage check.
+`PrecisionWeights` are the exact inverse variances and `PrecisionMatrix` the exact
+inverse covariance, with the scale known; both use the normal critical value for
+confidence intervals. `vcov(fit)` is the parameter covariance and `stderror(fit)`
+its square-rooted diagonal. The "Weights" page of the manual has the derivation
+and a coverage check.
+
+!!! warning "Deprecated"
+    Passing a bare inverse-variance `Vector` or inverse-covariance `Matrix` is
+    deprecated. Use `PrecisionWeights(1 ./ σ.^2)` / `PrecisionMatrix(inv(Σ))` for
+    the same known-variance covariance (with a calibrated normal interval), or
+    `AnalyticWeights` to estimate the scale.
 
 ## Example
 ```julia
@@ -296,6 +298,7 @@ function curve_fit(
     kwargs...,
 )
     check_data_health(xdata, ydata, wt)
+    _maybe_depwarn_bare_weights(wt)
     # construct a weighted cost function, with a vector weight for each ydata
     # for example, this might be wt = 1/sigma where sigma is some error term
     u = sqrt.(wt) # to be consistant with the matrix form
@@ -320,6 +323,7 @@ function curve_fit(
     kwargs...,
 )
     check_data_health(xdata, ydata, wt)
+    _maybe_depwarn_bare_weights(wt)
     u = sqrt.(wt) # to be consistant with the matrix form
 
     if inplace
@@ -342,6 +346,7 @@ function curve_fit(
     kwargs...,
 )
     check_data_health(xdata, ydata, wt)
+    _maybe_depwarn_bare_weights(wt)
 
     # as before, construct a weighted cost function with where this
     # method uses a matrix weight.
@@ -366,6 +371,7 @@ function curve_fit(
     kwargs...,
 )
     check_data_health(xdata, ydata, wt)
+    _maybe_depwarn_bare_weights(wt)
 
     u = cholesky(wt).U
 
@@ -411,6 +417,22 @@ struct PrecisionMatrix{T,M<:AbstractMatrix{T}} <: AbstractMatrix{T}
 end
 Base.size(pm::PrecisionMatrix) = size(pm.values)
 Base.getindex(pm::PrecisionMatrix, i::Int, j::Int) = pm.values[i, j]
+
+# Bare (untyped) vector/matrix weights are deprecated in favour of the typed
+# weight forms, which make the variance assumption explicit and use the matching
+# confidence interval. The typed weights subtype `AbstractVector`/`AbstractMatrix`,
+# so they reach the same `curve_fit` methods; these dispatches keep them silent
+# and warn only for a plain vector or matrix.
+_maybe_depwarn_bare_weights(::AbstractWeights) = nothing
+_maybe_depwarn_bare_weights(::PrecisionMatrix) = nothing
+function _maybe_depwarn_bare_weights(::AbstractVector)
+    Base.depwarn("Passing weights as a bare `Vector` is deprecated. Wrap the inverse variances `1 ./ σ.^2` in `PrecisionWeights` to keep the known-variance covariance (now with the calibrated normal confidence interval instead of Student-t), or in `AnalyticWeights` to estimate the scale.", :curve_fit)
+    return nothing
+end
+function _maybe_depwarn_bare_weights(::AbstractMatrix)
+    Base.depwarn("Passing weights as a bare `Matrix` is deprecated. Wrap the inverse covariance `inv(Σ)` in `PrecisionMatrix` instead (this also switches the confidence interval from Student-t to the calibrated normal quantile).", :curve_fit)
+    return nothing
+end
 
 # Whether the residual scale σ² is estimated from the fit and multiplied into the
 # covariance, or assumed known because the weights are the exact inverse

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -445,12 +445,21 @@ function StatsAPI.stderror(fit::LsqFitResult; rtol::Real = NaN, atol::Real = 0)
 end
 
 # Reference distribution for confidence intervals / margins of error.
-# When the residual scale σ² is estimated (unweighted, `AnalyticWeights`,
-# `FrequencyWeights`) the standardized estimate follows Student-t with `dof`
-# degrees of freedom. When σ² is known (a bare inverse-variance vector or an
-# inverse-covariance matrix) there is no estimated scale, so the estimate is
-# asymptotically standard normal and the normal (asymptotic) quantile is used.
-_ci_dist(fit::LsqFitResult) = _estimates_scale(fit.wt) ? TDist(dof(fit)) : Normal()
+#
+# Untyped weight inputs (a bare vector, an inverse-covariance matrix) and the
+# unweighted case keep the Student-t reference for backwards compatibility, even
+# when the scale is known (for which the normal would be the asymptotically
+# correct choice — see the "Weights" manual page). This makes those intervals
+# mildly conservative but never anti-conservative, and preserves historical
+# behaviour.
+#
+# Typed `AbstractWeights` instead select the asymptotically-correct reference:
+# Student-t when the scale is estimated (`AnalyticWeights`, `FrequencyWeights`)
+# and the standard normal when it is known. The normal branch is therefore only
+# reachable through a typed, known-scale weight.
+_ci_dist(fit::LsqFitResult) = _ci_dist(fit.wt, dof(fit))
+_ci_dist(wt, dof) = TDist(dof)
+_ci_dist(wt::AbstractWeights, dof) = _estimates_scale(wt) ? TDist(dof) : Normal()
 
 function margin_error(fit::LsqFitResult, alpha = 0.05; rtol::Real = NaN, atol::Real = 0)
     # computes margin of error at alpha significance level from

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -207,14 +207,20 @@ The type of `wt` sets whether the residual scale `σ²` is known or estimated:
 | omitted | estimated | `σ̂² (JᵀJ)⁻¹` |
 | `1 ./ σ.^2` (vector) | known | `(JᵀWJ)⁻¹` |
 | `inv(Σ)` (matrix) | known | `(JᵀWJ)⁻¹` |
+| `PrecisionWeights(1 ./ σ.^2)` | known | `(JᵀWJ)⁻¹` |
+| `PrecisionMatrix(inv(Σ))` | known | `(JᵀWJ)⁻¹` |
 | `AnalyticWeights(1 ./ σ.^2)` | estimated | `σ̂² (JᵀWJ)⁻¹` |
 | `FrequencyWeights(counts)` | estimated, `nobs=∑w` | `σ̂² (JᵀWJ)⁻¹` |
 
 `AnalyticWeights` are relative inverse-variance weights and do not depend on the
-overall scale of the weights, matching MATLAB `nlinfit`, Origin and LabPlot. A
-bare vector is taken as the exact inverse variances. `vcov(fit)` is the parameter
-covariance and `stderror(fit)` its square-rooted diagonal. The "Weights" page of
-the manual has the derivation and a coverage check.
+overall scale of the weights, matching MATLAB `nlinfit`, Origin and LabPlot.
+`PrecisionWeights` (and a bare vector) are the exact inverse variances and
+`PrecisionMatrix` (and a bare matrix) the exact inverse covariance, with the
+scale known. The typed forms (`PrecisionWeights`, `PrecisionMatrix`) use the
+normal critical value for confidence intervals; the bare vector and matrix keep
+Student-t. `vcov(fit)` is the parameter covariance and `stderror(fit)` its
+square-rooted diagonal. The "Weights" page of the manual has the derivation and a
+coverage check.
 
 ## Example
 ```julia
@@ -368,14 +374,53 @@ function curve_fit(
     lmfit(f, g, p0, wt; kwargs...)
 end
 
+"""
+    PrecisionWeights(vs)
+
+Weights whose values are the exact, known inverse variances `1 ./ σ.^2` of the
+observations. The residual scale is treated as known rather than estimated, so
+`vcov` is `(JᵀWJ)⁻¹` with no mean-squared-error factor and confidence intervals
+use the normal (asymptotic) critical value.
+
+This is the typed equivalent of passing a bare inverse-variance vector. Use
+`AnalyticWeights` instead when the weights are only relative precisions and the
+scale should be estimated.
+"""
+struct PrecisionWeights{S<:Real,T<:Real,V<:AbstractVector{T}} <: AbstractWeights{S,T,V}
+    values::V
+    sum::S
+end
+function PrecisionWeights(vs::AbstractVector{<:Real})
+    s = sum(vs)
+    return PrecisionWeights{typeof(s),eltype(vs),typeof(vs)}(vs, s)
+end
+
+"""
+    PrecisionMatrix(m)
+
+The exact, known **precision matrix** (inverse covariance) `inv(Σ)` of correlated
+observations. This is the matrix counterpart of [`PrecisionWeights`](@ref): the
+residual scale is treated as known, so `vcov` is `(JᵀWJ)⁻¹` with no
+mean-squared-error factor and confidence intervals use the normal critical value.
+
+!!! note
+    The argument is the precision matrix `inv(Σ)`, not the covariance `Σ`.
+"""
+struct PrecisionMatrix{T,M<:AbstractMatrix{T}} <: AbstractMatrix{T}
+    values::M
+end
+Base.size(pm::PrecisionMatrix) = size(pm.values)
+Base.getindex(pm::PrecisionMatrix, i::Int, j::Int) = pm.values[i, j]
+
 # Whether the residual scale σ² is estimated from the fit and multiplied into the
 # covariance, or assumed known because the weights are the exact inverse
 # (co)variance. Unweighted, AnalyticWeights and FrequencyWeights estimate it; a
-# bare vector or matrix takes it as known.
+# bare vector or matrix, PrecisionWeights or PrecisionMatrix, takes it as known.
 _estimates_scale(wt::AbstractVector) = isempty(wt)
 _estimates_scale(wt::AbstractMatrix) = false
 _estimates_scale(wt::AnalyticWeights) = true
 _estimates_scale(wt::FrequencyWeights) = true
+_estimates_scale(wt::PrecisionWeights) = false
 # ProbabilityWeights need a survey/sandwich variance and Weights has no bias
 # correction in StatsBase, so error instead of returning a mismatched covariance.
 function _estimates_scale(wt::Union{ProbabilityWeights,Weights})
@@ -428,11 +473,12 @@ end
 
 # Reference distribution for confidence intervals and margins of error. Untyped
 # inputs (bare vector, matrix) and the unweighted case keep Student-t for
-# backwards compatibility. Typed weights use Student-t when the scale is
-# estimated and the normal quantile when it is known.
+# backwards compatibility. Typed inputs use Student-t when the scale is estimated
+# and the normal quantile when it is known.
 _ci_dist(fit::LsqFitResult) = _ci_dist(fit.wt, dof(fit))
 _ci_dist(wt, dof) = TDist(dof)
 _ci_dist(wt::AbstractWeights, dof) = _estimates_scale(wt) ? TDist(dof) : Normal()
+_ci_dist(wt::PrecisionMatrix, dof) = Normal()
 
 function margin_error(fit::LsqFitResult, alpha = 0.05; rtol::Real = NaN, atol::Real = 0)
     # computes margin of error at alpha significance level from

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -343,17 +343,22 @@ end
 
 function StatsAPI.vcov(fit::LsqFitResult)
     # computes covariance matrix of fit parameters
+
+    # Both branches use the QR decomposition of the Jacobian, which is
+    # numerically more stable than forming and inverting J'J directly
+    # (note inv(J'J) == inv(R'R) == Rinv * Rinv').
     J = fit.jacobian
+    Q, R = qr(J)
+    Rinv = inv(R)
+    covar = Rinv * Rinv'
 
+    # In the weighted case the weights are folded into the residuals and
+    # hence into J (so J'J == Jraw' * W * Jraw). They are treated as the
+    # known inverse (co)variance, the residual scale is fixed to one, and
+    # no further variance estimate is applied. In the unweighted case the
+    # residual variance is unknown and estimated by the mean squared error.
     if isempty(fit.wt)
-        r = fit.resid
-
-        # compute the covariance matrix from the QR decomposition
-        Q, R = qr(J)
-        Rinv = inv(R)
-        covar = Rinv * Rinv' * mse(fit)
-    else
-        covar = inv(J' * J)
+        covar = covar * mse(fit)
     end
 
     return covar

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -9,9 +9,8 @@ end
 
 StatsAPI.coef(lfr::LsqFitResult) = lfr.param
 StatsAPI.dof(lfr::LsqFitResult) = nobs(lfr) - length(coef(lfr))
-# For `FrequencyWeights` each weight is a repeat count, so the number of
-# observations is the sum of the counts; for every other weighting it is the
-# number of residuals.
+# With FrequencyWeights each weight is a count, so nobs is their sum; otherwise
+# it is the number of residuals.
 StatsAPI.nobs(lfr::LsqFitResult) = _nobs(lfr.wt, lfr.resid)
 _nobs(wt, resid) = length(resid)
 _nobs(wt::FrequencyWeights, resid) = sum(wt)
@@ -194,33 +193,28 @@ additionally, it is possible to query the degrees of freedom with
 * `dof(fit)`
 * `coef(fit)`
 
-## Weights and what they mean
+## Weights
 
-The *values* you pass are always in **inverse-variance** units, never standard
-deviations:
+The values of `wt` are inverse variances, not standard deviations. A vector
+weights the squared residuals `∑ wtᵢ (model−y)ᵢ²`, so the optimal choice is
+`wtᵢ = 1/σᵢ²`. A matrix is the inverse covariance `Σ⁻¹` of the observations (a
+diagonal of `1/σᵢ²` is the vector case).
 
-* a **vector** `wt` weights the squared residuals, `∑ wtᵢ (model−y)²ᵢ`, so the
-  optimal choice is the **inverse variance** `wtᵢ = 1/σᵢ²` (not `1/σᵢ`);
-* a **matrix** `wt` is the **inverse covariance** of the observations, `Σ⁻¹`
-  (a diagonal matrix of `1/σᵢ²` is exactly the vector case).
+The type of `wt` sets whether the residual scale `σ²` is known or estimated:
 
-What changes the reported uncertainty is the *type* of `wt`, which states
-whether the residual scale `σ²` is known or estimated:
+| `wt` | scale `σ²` | `vcov(fit)` |
+|:-----|:-----------|:------------|
+| omitted | estimated | `σ̂² (JᵀJ)⁻¹` |
+| `1 ./ σ.^2` (vector) | known | `(JᵀWJ)⁻¹` |
+| `inv(Σ)` (matrix) | known | `(JᵀWJ)⁻¹` |
+| `AnalyticWeights(1 ./ σ.^2)` | estimated | `σ̂² (JᵀWJ)⁻¹` |
+| `FrequencyWeights(counts)` | estimated, `nobs=∑w` | `σ̂² (JᵀWJ)⁻¹` |
 
-| `wt`                                  | residual scale `σ²` | `vcov(fit)`        |
-|:--------------------------------------|:--------------------|:-------------------|
-| omitted (unweighted)                  | estimated           | `σ̂² (JᵀJ)⁻¹`       |
-| bare vector `1 ./ σ.^2`               | known (`≡ 1`)       | `(JᵀWJ)⁻¹`         |
-| matrix `inv(Σ)`                       | known (`≡ 1`)       | `(JᵀWJ)⁻¹`         |
-| `AnalyticWeights(1 ./ σ.^2)`          | estimated           | `σ̂² (JᵀWJ)⁻¹`      |
-| `FrequencyWeights(counts)`            | estimated, `nobs=∑w`| `σ̂² (JᵀWJ)⁻¹`      |
-
-`AnalyticWeights` are *relative* inverse-variance (reliability/precision)
-weights and are scale-invariant — this matches the convention used by MATLAB
-`nlinfit`, Origin and LabPlot. A bare vector instead asserts that you know the
-exact inverse variances. `vcov(fit)` returns the parameter **covariance** matrix
-and `stderror(fit)` its diagonal **standard deviations** (`√diag`). See the
-"Weights" page of the manual for the full derivation and Monte-Carlo coverage.
+`AnalyticWeights` are relative inverse-variance weights and do not depend on the
+overall scale of the weights, matching MATLAB `nlinfit`, Origin and LabPlot. A
+bare vector is taken as the exact inverse variances. `vcov(fit)` is the parameter
+covariance and `stderror(fit)` its square-rooted diagonal. The "Weights" page of
+the manual has the derivation and a coverage check.
 
 ## Example
 ```julia
@@ -374,23 +368,16 @@ function curve_fit(
     lmfit(f, g, p0, wt; kwargs...)
 end
 
-# Whether the overall residual scale (variance) σ² is *estimated* from the fit
-# and multiplied into the covariance (`σ̂² · (JᵀWJ)⁻¹`), or assumed *known* and
-# equal to one because the supplied weights already are the exact inverse
-# (co)variance (`(JᵀWJ)⁻¹`). See the "Weights" section of the manual.
-#
-#   - unweighted fit ............... estimate  (the classic σ̂² = RSS/(n−p))
-#   - bare inverse-variance vector . known     (you asserted the exact 1/σ²ᵢ)
-#   - inverse-covariance matrix .... known     (you asserted the exact Σ⁻¹)
-#   - AnalyticWeights .............. estimate  (relative precision; scale-invariant)
-#   - FrequencyWeights ............. estimate  (repeat counts; nobs = ∑w)
+# Whether the residual scale σ² is estimated from the fit and multiplied into the
+# covariance, or assumed known because the weights are the exact inverse
+# (co)variance. Unweighted, AnalyticWeights and FrequencyWeights estimate it; a
+# bare vector or matrix takes it as known.
 _estimates_scale(wt::AbstractVector) = isempty(wt)
 _estimates_scale(wt::AbstractMatrix) = false
 _estimates_scale(wt::AnalyticWeights) = true
 _estimates_scale(wt::FrequencyWeights) = true
-# `ProbabilityWeights` need a sandwich/survey variance and `Weights` carries no
-# covariance semantics (StatsBase itself refuses a bias correction for it), so
-# we refuse rather than return a silently wrong covariance.
+# ProbabilityWeights need a survey/sandwich variance and Weights has no bias
+# correction in StatsBase, so error instead of returning a mismatched covariance.
 function _estimates_scale(wt::Union{ProbabilityWeights,Weights})
     throw(
         ArgumentError(
@@ -403,20 +390,15 @@ function _estimates_scale(wt::Union{ProbabilityWeights,Weights})
 end
 
 function StatsAPI.vcov(fit::LsqFitResult)
-    # computes covariance matrix of fit parameters
-
-    # The covariance is built from the QR decomposition of the (weight-folded)
-    # Jacobian, which is numerically more stable than forming and inverting
-    # JᵀJ directly (note inv(JᵀJ) == inv(RᵀR) == Rinv * Rinv'). Because the
-    # weights are folded into the residuals and hence into J, JᵀJ already
-    # equals Jrawᵀ W Jraw.
+    # Covariance from the QR decomposition of the (weight-folded) Jacobian, which
+    # is more stable than inverting JᵀJ directly (inv(JᵀJ) == Rinv * Rinv'). The
+    # weights are folded into J, so JᵀJ already equals Jrawᵀ W Jraw.
     J = fit.jacobian
     Q, R = qr(J)
     Rinv = inv(R)
     covar = Rinv * Rinv'
 
-    # Multiply by the estimated residual variance only when the scale is not
-    # assumed known from the weights (see `_estimates_scale`).
+    # Scale by the estimated residual variance unless the weights fix it.
     if _estimates_scale(fit.wt)
         covar = covar * mse(fit)
     end
@@ -444,19 +426,10 @@ function StatsAPI.stderror(fit::LsqFitResult; rtol::Real = NaN, atol::Real = 0)
     return sqrt.(abs.(vars))
 end
 
-# Reference distribution for confidence intervals / margins of error.
-#
-# Untyped weight inputs (a bare vector, an inverse-covariance matrix) and the
-# unweighted case keep the Student-t reference for backwards compatibility, even
-# when the scale is known (for which the normal would be the asymptotically
-# correct choice — see the "Weights" manual page). This makes those intervals
-# mildly conservative but never anti-conservative, and preserves historical
-# behaviour.
-#
-# Typed `AbstractWeights` instead select the asymptotically-correct reference:
-# Student-t when the scale is estimated (`AnalyticWeights`, `FrequencyWeights`)
-# and the standard normal when it is known. The normal branch is therefore only
-# reachable through a typed, known-scale weight.
+# Reference distribution for confidence intervals and margins of error. Untyped
+# inputs (bare vector, matrix) and the unweighted case keep Student-t for
+# backwards compatibility. Typed weights use Student-t when the scale is
+# estimated and the normal quantile when it is known.
 _ci_dist(fit::LsqFitResult) = _ci_dist(fit.wt, dof(fit))
 _ci_dist(wt, dof) = TDist(dof)
 _ci_dist(wt::AbstractWeights, dof) = _estimates_scale(wt) ? TDist(dof) : Normal()

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -9,7 +9,12 @@ end
 
 StatsAPI.coef(lfr::LsqFitResult) = lfr.param
 StatsAPI.dof(lfr::LsqFitResult) = nobs(lfr) - length(coef(lfr))
-StatsAPI.nobs(lfr::LsqFitResult) = length(lfr.resid)
+# For `FrequencyWeights` each weight is a repeat count, so the number of
+# observations is the sum of the counts; for every other weighting it is the
+# number of residuals.
+StatsAPI.nobs(lfr::LsqFitResult) = _nobs(lfr.wt, lfr.resid)
+_nobs(wt, resid) = length(resid)
+_nobs(wt::FrequencyWeights, resid) = sum(wt)
 StatsAPI.rss(lfr::LsqFitResult) = sum(abs2, lfr.resid)
 StatsAPI.weights(lfr::LsqFitResult) = lfr.wt
 StatsAPI.residuals(lfr::LsqFitResult) = lfr.resid
@@ -178,7 +183,7 @@ end
     curve_fit(model, xdata, ydata, wt, p0) -> fit
 
 Fit data to a non-linear `model`. `p0` is an initial model parameter guess (see Example),
-and `wt` is an optional array of weights.
+and `wt` is an optional weighting of the observations.
 The return object is a composite type (`LsqFitResult`), with some interesting values:
 
 * `fit.resid` : residuals = vector of residuals
@@ -188,6 +193,34 @@ additionally, it is possible to query the degrees of freedom with
 
 * `dof(fit)`
 * `coef(fit)`
+
+## Weights and what they mean
+
+The *values* you pass are always in **inverse-variance** units, never standard
+deviations:
+
+* a **vector** `wt` weights the squared residuals, `∑ wtᵢ (model−y)²ᵢ`, so the
+  optimal choice is the **inverse variance** `wtᵢ = 1/σᵢ²` (not `1/σᵢ`);
+* a **matrix** `wt` is the **inverse covariance** of the observations, `Σ⁻¹`
+  (a diagonal matrix of `1/σᵢ²` is exactly the vector case).
+
+What changes the reported uncertainty is the *type* of `wt`, which states
+whether the residual scale `σ²` is known or estimated:
+
+| `wt`                                  | residual scale `σ²` | `vcov(fit)`        |
+|:--------------------------------------|:--------------------|:-------------------|
+| omitted (unweighted)                  | estimated           | `σ̂² (JᵀJ)⁻¹`       |
+| bare vector `1 ./ σ.^2`               | known (`≡ 1`)       | `(JᵀWJ)⁻¹`         |
+| matrix `inv(Σ)`                       | known (`≡ 1`)       | `(JᵀWJ)⁻¹`         |
+| `AnalyticWeights(1 ./ σ.^2)`          | estimated           | `σ̂² (JᵀWJ)⁻¹`      |
+| `FrequencyWeights(counts)`            | estimated, `nobs=∑w`| `σ̂² (JᵀWJ)⁻¹`      |
+
+`AnalyticWeights` are *relative* inverse-variance (reliability/precision)
+weights and are scale-invariant — this matches the convention used by MATLAB
+`nlinfit`, Origin and LabPlot. A bare vector instead asserts that you know the
+exact inverse variances. `vcov(fit)` returns the parameter **covariance** matrix
+and `stderror(fit)` its diagonal **standard deviations** (`√diag`). See the
+"Weights" page of the manual for the full derivation and Monte-Carlo coverage.
 
 ## Example
 ```julia
@@ -341,23 +374,50 @@ function curve_fit(
     lmfit(f, g, p0, wt; kwargs...)
 end
 
+# Whether the overall residual scale (variance) σ² is *estimated* from the fit
+# and multiplied into the covariance (`σ̂² · (JᵀWJ)⁻¹`), or assumed *known* and
+# equal to one because the supplied weights already are the exact inverse
+# (co)variance (`(JᵀWJ)⁻¹`). See the "Weights" section of the manual.
+#
+#   - unweighted fit ............... estimate  (the classic σ̂² = RSS/(n−p))
+#   - bare inverse-variance vector . known     (you asserted the exact 1/σ²ᵢ)
+#   - inverse-covariance matrix .... known     (you asserted the exact Σ⁻¹)
+#   - AnalyticWeights .............. estimate  (relative precision; scale-invariant)
+#   - FrequencyWeights ............. estimate  (repeat counts; nobs = ∑w)
+_estimates_scale(wt::AbstractVector) = isempty(wt)
+_estimates_scale(wt::AbstractMatrix) = false
+_estimates_scale(wt::AnalyticWeights) = true
+_estimates_scale(wt::FrequencyWeights) = true
+# `ProbabilityWeights` need a sandwich/survey variance and `Weights` carries no
+# covariance semantics (StatsBase itself refuses a bias correction for it), so
+# we refuse rather than return a silently wrong covariance.
+function _estimates_scale(wt::Union{ProbabilityWeights,Weights})
+    throw(
+        ArgumentError(
+            "Covariance estimation is not defined for `$(nameof(typeof(wt)))`. " *
+            "Use `AnalyticWeights` (relative inverse-variance weights), " *
+            "`FrequencyWeights` (integer counts), a bare vector of exact inverse " *
+            "variances `1 ./ σ.^2`, or an inverse-covariance matrix `inv(Σ)`.",
+        ),
+    )
+end
+
 function StatsAPI.vcov(fit::LsqFitResult)
     # computes covariance matrix of fit parameters
 
-    # Both branches use the QR decomposition of the Jacobian, which is
-    # numerically more stable than forming and inverting J'J directly
-    # (note inv(J'J) == inv(R'R) == Rinv * Rinv').
+    # The covariance is built from the QR decomposition of the (weight-folded)
+    # Jacobian, which is numerically more stable than forming and inverting
+    # JᵀJ directly (note inv(JᵀJ) == inv(RᵀR) == Rinv * Rinv'). Because the
+    # weights are folded into the residuals and hence into J, JᵀJ already
+    # equals Jrawᵀ W Jraw.
     J = fit.jacobian
     Q, R = qr(J)
     Rinv = inv(R)
     covar = Rinv * Rinv'
 
-    # In the weighted case the weights are folded into the residuals and
-    # hence into J (so J'J == Jraw' * W * Jraw). They are treated as the
-    # known inverse (co)variance, the residual scale is fixed to one, and
-    # no further variance estimate is applied. In the unweighted case the
-    # residual variance is unknown and estimated by the mean squared error.
-    if isempty(fit.wt)
+    # Multiply by the estimated residual variance only when the scale is not
+    # assumed known from the weights (see `_estimates_scale`).
+    if _estimates_scale(fit.wt)
         covar = covar * mse(fit)
     end
 
@@ -384,6 +444,14 @@ function StatsAPI.stderror(fit::LsqFitResult; rtol::Real = NaN, atol::Real = 0)
     return sqrt.(abs.(vars))
 end
 
+# Reference distribution for confidence intervals / margins of error.
+# When the residual scale σ² is estimated (unweighted, `AnalyticWeights`,
+# `FrequencyWeights`) the standardized estimate follows Student-t with `dof`
+# degrees of freedom. When σ² is known (a bare inverse-variance vector or an
+# inverse-covariance matrix) there is no estimated scale, so the estimate is
+# asymptotically standard normal and the normal (asymptotic) quantile is used.
+_ci_dist(fit::LsqFitResult) = _estimates_scale(fit.wt) ? TDist(dof(fit)) : Normal()
+
 function margin_error(fit::LsqFitResult, alpha = 0.05; rtol::Real = NaN, atol::Real = 0)
     # computes margin of error at alpha significance level from
     #   fit   : a LsqFitResult from a curve_fit()
@@ -391,9 +459,9 @@ function margin_error(fit::LsqFitResult, alpha = 0.05; rtol::Real = NaN, atol::R
     #   atol  : absolute tolerance for approximate comparisson to 0.0 in negativity check
     #   rtol  : relative tolerance for approximate comparisson to 0.0 in negativity check
     std_errors = stderror(fit; rtol = rtol, atol = atol)
-    dist = TDist(dof(fit))
+    dist = _ci_dist(fit)
     critical_values = eltype(coef(fit))(quantile(dist, Float64(1 - alpha / 2)))
-    # scale standard errors by quantile of the student-t distribution (critical values)
+    # scale standard errors by the quantile of the reference distribution
     return std_errors * critical_values
 end
 

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -58,13 +58,13 @@ using LsqFit, Test, StableRNGs, LinearAlgebra
         yvars = T.(1e-6 * rand(rng, length(xdata)))
         ydata = T.(model(xdata, [1.0, 2.0]) + sqrt.(yvars) .* randn(rng, length(xdata)))
 
-        fit = curve_fit(model, xdata, ydata, 1 ./ yvars, T.([0.5, 0.5]))
+        fit = curve_fit(model, xdata, ydata, PrecisionWeights(1 ./ yvars), T.([0.5, 0.5]))
 
         @test norm(fit.param - [1.0, 2.0]) < 0.05
         @test fit.converged
 
         # test matrix valued weights ( #161 )
-        weights = LinearAlgebra.diagm(1 ./ yvars)
+        weights = PrecisionMatrix(LinearAlgebra.diagm(1 ./ yvars))
         fit_matrixweights = curve_fit(model, xdata, ydata, weights, T.([0.5, 0.5]))
         @test fit.param == fit_matrixweights.param
 
@@ -74,7 +74,7 @@ using LsqFit, Test, StableRNGs, LinearAlgebra
         @test norm(errors - [0.017, 0.075]) < 0.1
 
         # test with user-supplied jacobian and weights
-        fit = curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, p0)
+        fit = curve_fit(model, jacobian_model, xdata, ydata, PrecisionWeights(1 ./ yvars), p0)
         println("norm(fit.param - [1.0, 2.0]) < 0.05 ? ", norm(fit.param - [1.0, 2.0]))
         @test norm(fit.param - [1.0, 2.0]) < 0.05
         @test fit.converged
@@ -84,7 +84,7 @@ using LsqFit, Test, StableRNGs, LinearAlgebra
             model,
             xdata,
             ydata,
-            1 ./ yvars,
+            PrecisionWeights(1 ./ yvars),
             BigFloat.(p0);
             x_tol = T(1e-20),
             g_tol = T(1e-20),
@@ -95,14 +95,14 @@ using LsqFit, Test, StableRNGs, LinearAlgebra
             jacobian_model,
             xdata,
             ydata,
-            1 ./ yvars,
+            PrecisionWeights(1 ./ yvars),
             BigFloat.(p0);
             x_tol = T(1e-20),
             g_tol = T(1e-20),
         )
         @test fit.converged
 
-        curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, [0.5, 0.5]; tau = 0.0001)
+        curve_fit(model, jacobian_model, xdata, ydata, PrecisionWeights(1 ./ yvars), [0.5, 0.5]; tau = 0.0001)
     end
 
 end
@@ -121,7 +121,7 @@ end
     p0 = [0.5, 0.5]
 
     wt = fill(1 / σ^2, length(xdata))
-    fit = curve_fit(model, xdata, ydata, wt, p0)
+    fit = curve_fit(model, xdata, ydata, PrecisionWeights(wt), p0)
 
     # QR-based covariance equals the algebraic inv(J'J); J already carries the
     # weights, so this is the known-inverse-variance covariance with no MSE.
@@ -130,13 +130,13 @@ end
     @test vcov(fit) ≉ inv(J' * J) * LsqFit.mse(fit)
 
     # Vector weights and the equivalent diagonal matrix weights agree.
-    fit_mat = curve_fit(model, xdata, ydata, LinearAlgebra.diagm(wt), p0)
+    fit_mat = curve_fit(model, xdata, ydata, PrecisionMatrix(LinearAlgebra.diagm(wt)), p0)
     @test vcov(fit) ≈ vcov(fit_mat)
 
     # Weights of one give the same parameter estimates as an unweighted fit,
     # but a different covariance: the unweighted case additionally estimates
     # the residual variance via the MSE (#255).
-    fit_ones = curve_fit(model, xdata, ydata, ones(length(xdata)), p0)
+    fit_ones = curve_fit(model, xdata, ydata, PrecisionWeights(ones(length(xdata))), p0)
     fit_unwt = curve_fit(model, xdata, ydata, p0)
     @test fit_ones.param ≈ fit_unwt.param
     @test vcov(fit_ones) ≈ vcov(fit_unwt) / LsqFit.mse(fit_unwt)

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -107,6 +107,41 @@ using LsqFit, Test, StableRNGs, LinearAlgebra
 
 end
 
+# Covariance of weighted fits, see #255. The weights are folded into the
+# Jacobian, so they are treated as the known inverse variance and the weighted
+# covariance is *not* scaled by the mean squared error. This documents the
+# intentional difference from the unweighted case and guards the QR refactor.
+@testset "weighted vcov (#255)" begin
+    model(x, p) = p[1] .* exp.(-x .* p[2])
+
+    rng = StableRNG(125)
+    xdata = range(0, stop = 10, length = 20)
+    σ = 0.05
+    ydata = model(xdata, [1.0, 2.0]) + σ * randn(rng, length(xdata))
+    p0 = [0.5, 0.5]
+
+    wt = fill(1 / σ^2, length(xdata))
+    fit = curve_fit(model, xdata, ydata, wt, p0)
+
+    # QR-based covariance equals the algebraic inv(J'J); J already carries the
+    # weights, so this is the known-inverse-variance covariance with no MSE.
+    J = fit.jacobian
+    @test vcov(fit) ≈ inv(J' * J)
+    @test vcov(fit) ≉ inv(J' * J) * LsqFit.mse(fit)
+
+    # Vector weights and the equivalent diagonal matrix weights agree.
+    fit_mat = curve_fit(model, xdata, ydata, LinearAlgebra.diagm(wt), p0)
+    @test vcov(fit) ≈ vcov(fit_mat)
+
+    # Weights of one give the same parameter estimates as an unweighted fit,
+    # but a different covariance: the unweighted case additionally estimates
+    # the residual variance via the MSE (#255).
+    fit_ones = curve_fit(model, xdata, ydata, ones(length(xdata)), p0)
+    fit_unwt = curve_fit(model, xdata, ydata, p0)
+    @test fit_ones.param ≈ fit_unwt.param
+    @test vcov(fit_ones) ≈ vcov(fit_unwt) / LsqFit.mse(fit_unwt)
+end
+
 @testset "autodiff" begin
     model(x, p) = p[1] .* exp.(-x .* p[2])
     rng = StableRNG(125)

--- a/test/curve_fit_inplace.jl
+++ b/test/curve_fit_inplace.jl
@@ -132,24 +132,24 @@ using LsqFit, Test, StableRNGs, LinearAlgebra
 
     println("--------------\nPerformance of curve_fit with weights")
 
-    curve_fit(model, xdata, ydata, 1 ./ yvars, [0.5, 0.5])
+    curve_fit(model, xdata, ydata, PrecisionWeights(1 ./ yvars), [0.5, 0.5])
     curve_fit(
         model_inplace,
         xdata,
         ydata,
-        1 ./ yvars,
+        PrecisionWeights(1 ./ yvars),
         [0.5, 0.5];
         inplace = true,
         maxIter = 100,
     )
 
-    curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, [0.5, 0.5])
+    curve_fit(model, jacobian_model, xdata, ydata, PrecisionWeights(1 ./ yvars), [0.5, 0.5])
     curve_fit(
         model_inplace,
         jacobian_model_inplace,
         xdata,
         ydata,
-        1 ./ yvars,
+        PrecisionWeights(1 ./ yvars),
         [0.5, 0.5];
         inplace = true,
         maxIter = 100,
@@ -162,7 +162,7 @@ using LsqFit, Test, StableRNGs, LinearAlgebra
         jacobian_model,
         xdata,
         ydata,
-        1 ./ yvars,
+        PrecisionWeights(1 ./ yvars),
         [0.5, 0.5];
         maxIter = 100,
     )
@@ -188,7 +188,7 @@ using LsqFit, Test, StableRNGs, LinearAlgebra
                     jacobian_model,
                     xxdata,
                     yydata,
-                    WWT,
+                    PrecisionWeights(WWT),
                     [0.5, 0.5];
                     maxIter = 100,
                 )
@@ -198,7 +198,7 @@ using LsqFit, Test, StableRNGs, LinearAlgebra
                     jacobian_model,
                     xxdata,
                     yydata,
-                    WWT,
+                    PrecisionWeights(WWT),
                     [0.5, 0.5];
                     maxIter = 100,
                 )
@@ -211,7 +211,7 @@ using LsqFit, Test, StableRNGs, LinearAlgebra
         model_inplace,
         xdata,
         ydata,
-        1 ./ yvars,
+        PrecisionWeights(1 ./ yvars),
         [0.5, 0.5];
         inplace = true,
         maxIter = 100,
@@ -226,7 +226,7 @@ using LsqFit, Test, StableRNGs, LinearAlgebra
         jacobian_model,
         xdata,
         ydata,
-        1 ./ yvars,
+        PrecisionWeights(1 ./ yvars),
         [0.5, 0.5];
         maxIter = 100,
     )
@@ -238,7 +238,7 @@ using LsqFit, Test, StableRNGs, LinearAlgebra
         jacobian_model_inplace,
         xdata,
         ydata,
-        1 ./ yvars,
+        PrecisionWeights(1 ./ yvars),
         [0.5, 0.5];
         inplace = true,
         maxIter = 100,

--- a/test/geodesic.jl
+++ b/test/geodesic.jl
@@ -122,13 +122,13 @@ using LsqFit, Test, StableRNGs
     ydata = model(xdata, [1.0, 2.0]) + sqrt.(yvars) .* randn(rng, length(xdata))
 
     #warm up
-    curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, p0; maxIter = 1)
+    curve_fit(model, jacobian_model, xdata, ydata, PrecisionWeights(1 ./ yvars), p0; maxIter = 1)
     curve_fit(
         model,
         jacobian_model,
         xdata,
         ydata,
-        1 ./ yvars,
+        PrecisionWeights(1 ./ yvars),
         p0;
         maxIter = 1,
         avv! = manual_avv!,
@@ -140,7 +140,7 @@ using LsqFit, Test, StableRNGs
         jacobian_model,
         xdata,
         ydata,
-        1 ./ yvars,
+        PrecisionWeights(1 ./ yvars),
         p0;
         maxIter = 1,
         avv! = auto_avv!,
@@ -152,7 +152,7 @@ using LsqFit, Test, StableRNGs
 
     println("\t Non-inplace")
     fit_wt =
-        @time curve_fit(model, jacobian_model, xdata, ydata, 1 ./ yvars, p0; maxIter = 100)
+        @time curve_fit(model, jacobian_model, xdata, ydata, PrecisionWeights(1 ./ yvars), p0; maxIter = 100)
     @test fit_wt.converged
 
 
@@ -162,7 +162,7 @@ using LsqFit, Test, StableRNGs
         jacobian_model,
         xdata,
         ydata,
-        1 ./ yvars,
+        PrecisionWeights(1 ./ yvars),
         p0;
         maxIter = 100,
         avv! = manual_avv!,
@@ -178,7 +178,7 @@ using LsqFit, Test, StableRNGs
         jacobian_model,
         xdata,
         ydata,
-        1 ./ yvars,
+        PrecisionWeights(1 ./ yvars),
         p0;
         maxIter = 100,
         avv! = auto_avv!,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,14 @@
 using LsqFit, Test, LinearAlgebra
 using NLSolversBase
 
-my_tests =
-    ["curve_fit.jl", "levenberg_marquardt.jl", "curve_fit_inplace.jl", "geodesic.jl", "qa.jl"]
+my_tests = [
+    "curve_fit.jl",
+    "weights.jl",
+    "levenberg_marquardt.jl",
+    "curve_fit_inplace.jl",
+    "geodesic.jl",
+    "qa.jl",
+]
 
 println("Running tests:")
 

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -77,9 +77,11 @@ using LsqFit, Test, LinearAlgebra, StableRNGs
                 hitK[k] += lo <= truth[k] <= hi
             end
         end
-        # AnalyticWeights (Student-t) and known-variance (normal quantile) should
-        # both be close to the nominal 95%.
+        # AnalyticWeights (estimate scale, Student-t) should be close to the
+        # nominal 95%. A bare vector keeps the Student-t reference for backwards
+        # compatibility, so with known variance it is mildly conservative
+        # (over-covers, never under-covers).
         @test all(abs.(100 .* hitA ./ N .- 95) .< 2)
-        @test all(abs.(100 .* hitK ./ N .- 95) .< 2)
+        @test all(100 .* hitK ./ N .>= 94)
     end
 end

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -1,0 +1,85 @@
+using LsqFit, Test, LinearAlgebra, StableRNGs
+
+@testset "typed weights (#255)" begin
+    model(x, p) = p[1] .* exp.(p[2] .* x)
+
+    # dataset from issue #255
+    x = Float64[1, 2, 4, 5, 8]
+    y = Float64[3, 4, 6, 11, 20]
+    σ = 0.05 .* y
+    wt = 1 ./ σ .^ 2
+    p0 = [2.0, 0.3]
+
+    fit_known = curve_fit(model, x, y, wt, p0)                  # bare vector: known variance
+    fit_rel = curve_fit(model, x, y, AnalyticWeights(wt), p0)   # estimate scale
+
+    @testset "point estimates agree, std errors differ" begin
+        @test coef(fit_known) ≈ coef(fit_rel) rtol = 1e-8
+        @test coef(fit_known) ≈ [2.263, 0.275] rtol = 1e-2
+        # bare vector reproduces the (small) known-variance errors
+        @test stderror(fit_known) ≈ [0.0968, 0.0091] rtol = 1e-2
+        # AnalyticWeights reproduce the Origin/LabPlot/mycurvefit errors
+        @test stderror(fit_rel) ≈ [0.2579, 0.0243] rtol = 1e-2
+        # the AnalyticWeights errors are larger (scale is estimated)
+        @test all(stderror(fit_rel) .> stderror(fit_known))
+    end
+
+    @testset "AnalyticWeights are scale-invariant" begin
+        se = stderror(curve_fit(model, x, y, AnalyticWeights(wt), p0))
+        se10 = stderror(curve_fit(model, x, y, AnalyticWeights(10 .* wt), p0))
+        @test se ≈ se10 rtol = 1e-6
+        # uniform AnalyticWeights == unweighted; a bare vector of ones does not
+        unwt = curve_fit(model, x, y, p0)
+        a1 = curve_fit(model, x, y, AnalyticWeights(ones(length(x))), p0)
+        @test stderror(a1) ≈ stderror(unwt) rtol = 1e-6
+        @test !isapprox(
+            stderror(curve_fit(model, x, y, ones(length(x)), p0)),
+            stderror(unwt),
+        )
+    end
+
+    @testset "vcov formulas" begin
+        J = fit_known.jacobian
+        @test vcov(fit_known) ≈ inv(J' * J) rtol = 1e-8                 # known: no MSE
+        @test vcov(fit_rel) ≈ inv(J' * J) * LsqFit.mse(fit_rel) rtol = 1e-8
+        @test stderror(fit_known) ≈ sqrt.(diag(vcov(fit_known)))
+    end
+
+    @testset "FrequencyWeights count observations" begin
+        counts = [3, 1, 1, 2, 1]
+        fit_freq = curve_fit(model, x, y, FrequencyWeights(counts), p0)
+        @test nobs(fit_freq) == sum(counts)
+        @test dof(fit_freq) == sum(counts) - length(p0)
+    end
+
+    @testset "unsupported weight types error" begin
+        @test_throws ArgumentError vcov(curve_fit(model, x, y, ProbabilityWeights(wt), p0))
+        @test_throws ArgumentError vcov(curve_fit(model, x, y, Weights(wt), p0))
+    end
+
+    @testset "Monte-Carlo coverage" begin
+        truth = [2.0, 0.25]
+        xg = collect(range(0.5, 6; length = 15))
+        rng = StableRNG(20240617)
+        N = 3000
+        hitA = zeros(2)
+        hitK = zeros(2)
+        for _ = 1:N
+            sd = 0.10 .* model(xg, truth)
+            yg = model(xg, truth) .+ sd .* randn(rng, length(xg))
+            w = 1 ./ sd .^ 2
+            fA = curve_fit(model, xg, yg, AnalyticWeights(w), copy(truth))  # estimate scale
+            fK = curve_fit(model, xg, yg, w, copy(truth))                   # known variance
+            for (k, (lo, hi)) in enumerate(confint(fA; level = 0.95))
+                hitA[k] += lo <= truth[k] <= hi
+            end
+            for (k, (lo, hi)) in enumerate(confint(fK; level = 0.95))
+                hitK[k] += lo <= truth[k] <= hi
+            end
+        end
+        # AnalyticWeights (Student-t) and known-variance (normal quantile) should
+        # both be close to the nominal 95%.
+        @test all(abs.(100 .* hitA ./ N .- 95) .< 2)
+        @test all(abs.(100 .* hitK ./ N .- 95) .< 2)
+    end
+end

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -10,13 +10,13 @@ using LsqFit, Test, LinearAlgebra, StableRNGs
     wt = 1 ./ σ .^ 2
     p0 = [2.0, 0.3]
 
-    fit_known = curve_fit(model, x, y, wt, p0)                  # bare vector: known variance
+    fit_known = curve_fit(model, x, y, PrecisionWeights(wt), p0) # known variance
     fit_rel = curve_fit(model, x, y, AnalyticWeights(wt), p0)   # estimate scale
 
     @testset "point estimates agree, std errors differ" begin
         @test coef(fit_known) ≈ coef(fit_rel) rtol = 1e-8
         @test coef(fit_known) ≈ [2.263, 0.275] rtol = 1e-2
-        # bare vector reproduces the (small) known-variance errors
+        # PrecisionWeights reproduce the (small) known-variance errors
         @test stderror(fit_known) ≈ [0.0968, 0.0091] rtol = 1e-2
         # AnalyticWeights reproduce the Origin/LabPlot/mycurvefit errors
         @test stderror(fit_rel) ≈ [0.2579, 0.0243] rtol = 1e-2
@@ -28,12 +28,12 @@ using LsqFit, Test, LinearAlgebra, StableRNGs
         se = stderror(curve_fit(model, x, y, AnalyticWeights(wt), p0))
         se10 = stderror(curve_fit(model, x, y, AnalyticWeights(10 .* wt), p0))
         @test se ≈ se10 rtol = 1e-6
-        # uniform AnalyticWeights == unweighted; a bare vector of ones does not
+        # uniform AnalyticWeights == unweighted; PrecisionWeights of ones do not
         unwt = curve_fit(model, x, y, p0)
         a1 = curve_fit(model, x, y, AnalyticWeights(ones(length(x))), p0)
         @test stderror(a1) ≈ stderror(unwt) rtol = 1e-6
         @test !isapprox(
-            stderror(curve_fit(model, x, y, ones(length(x)), p0)),
+            stderror(curve_fit(model, x, y, PrecisionWeights(ones(length(x))), p0)),
             stderror(unwt),
         )
     end
@@ -45,28 +45,38 @@ using LsqFit, Test, LinearAlgebra, StableRNGs
         @test stderror(fit_known) ≈ sqrt.(diag(vcov(fit_known)))
     end
 
-    @testset "PrecisionWeights match the bare vector with a normal CI" begin
-        fit_var = curve_fit(model, x, y, PrecisionWeights(wt), p0)
-        # same known-variance covariance as the bare vector
-        @test coef(fit_var) ≈ coef(fit_known) rtol = 1e-8
-        @test vcov(fit_var) ≈ vcov(fit_known) rtol = 1e-8
-        @test stderror(fit_var) ≈ stderror(fit_known) rtol = 1e-8
-        # but a tighter (normal) confidence interval than the bare vector's t
+    @testset "bare vector/matrix weights are deprecated" begin
         wid(f) = [hi - lo for (lo, hi) in confint(f; level = 0.95)]
-        @test all(wid(fit_var) .< wid(fit_known))
-    end
 
-    @testset "PrecisionMatrix matches a bare matrix with a normal CI" begin
+        # A bare vector warns and falls back to the known-variance covariance with
+        # a Student-t interval; PrecisionWeights gives the same covariance but the
+        # calibrated (tighter) normal interval.
+        fit_bare = @test_logs (:warn, r"deprecated") match_mode = :any curve_fit(
+            model,
+            x,
+            y,
+            wt,
+            p0,
+        )
+        @test coef(fit_bare) ≈ coef(fit_known) rtol = 1e-8
+        @test vcov(fit_bare) ≈ vcov(fit_known) rtol = 1e-8
+        @test stderror(fit_bare) ≈ stderror(fit_known) rtol = 1e-8
+        @test all(wid(fit_known) .< wid(fit_bare))   # PrecisionWeights normal < bare t
+
+        # Same story for a bare matrix vs PrecisionMatrix.
         M = LinearAlgebra.diagm(wt)                         # diagonal precision matrix
-        fit_mat = curve_fit(model, x, y, M, p0)            # bare matrix
+        fit_bare_mat = @test_logs (:warn, r"deprecated") match_mode = :any curve_fit(
+            model,
+            x,
+            y,
+            M,
+            p0,
+        )
         fit_pm = curve_fit(model, x, y, PrecisionMatrix(M), p0)
-        # a diagonal precision matrix equals the bare-vector / PrecisionWeights fit
         @test coef(fit_pm) ≈ coef(fit_known) rtol = 1e-8
         @test vcov(fit_pm) ≈ vcov(fit_known) rtol = 1e-8
-        @test vcov(fit_pm) ≈ vcov(fit_mat) rtol = 1e-8
-        # PrecisionMatrix uses the normal CI, the bare matrix keeps Student-t
-        wid(f) = [hi - lo for (lo, hi) in confint(f; level = 0.95)]
-        @test all(wid(fit_pm) .< wid(fit_mat))
+        @test vcov(fit_pm) ≈ vcov(fit_bare_mat) rtol = 1e-8
+        @test all(wid(fit_pm) .< wid(fit_bare_mat))
     end
 
     @testset "FrequencyWeights count observations" begin
@@ -87,25 +97,24 @@ using LsqFit, Test, LinearAlgebra, StableRNGs
         rng = StableRNG(20240617)
         N = 3000
         hitA = zeros(2)
-        hitK = zeros(2)
+        hitV = zeros(2)
         for _ = 1:N
             sd = 0.10 .* model(xg, truth)
             yg = model(xg, truth) .+ sd .* randn(rng, length(xg))
             w = 1 ./ sd .^ 2
             fA = curve_fit(model, xg, yg, AnalyticWeights(w), copy(truth))  # estimate scale
-            fK = curve_fit(model, xg, yg, w, copy(truth))                   # known variance
+            fV = curve_fit(model, xg, yg, PrecisionWeights(w), copy(truth)) # known variance
             for (k, (lo, hi)) in enumerate(confint(fA; level = 0.95))
                 hitA[k] += lo <= truth[k] <= hi
             end
-            for (k, (lo, hi)) in enumerate(confint(fK; level = 0.95))
-                hitK[k] += lo <= truth[k] <= hi
+            for (k, (lo, hi)) in enumerate(confint(fV; level = 0.95))
+                hitV[k] += lo <= truth[k] <= hi
             end
         end
-        # AnalyticWeights (estimate scale, Student-t) should be close to the
-        # nominal 95%. A bare vector keeps the Student-t reference for backwards
-        # compatibility, so with known variance it is mildly conservative
-        # (over-covers, never under-covers).
+        # AnalyticWeights (estimate scale, Student-t) and PrecisionWeights (known
+        # variance, normal) should both be close to the nominal 95%, each with the
+        # reference distribution matching its assumption.
         @test all(abs.(100 .* hitA ./ N .- 95) .< 2)
-        @test all(100 .* hitK ./ N .>= 94)
+        @test all(abs.(100 .* hitV ./ N .- 95) .< 2.5)
     end
 end

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -45,6 +45,30 @@ using LsqFit, Test, LinearAlgebra, StableRNGs
         @test stderror(fit_known) ≈ sqrt.(diag(vcov(fit_known)))
     end
 
+    @testset "PrecisionWeights match the bare vector with a normal CI" begin
+        fit_var = curve_fit(model, x, y, PrecisionWeights(wt), p0)
+        # same known-variance covariance as the bare vector
+        @test coef(fit_var) ≈ coef(fit_known) rtol = 1e-8
+        @test vcov(fit_var) ≈ vcov(fit_known) rtol = 1e-8
+        @test stderror(fit_var) ≈ stderror(fit_known) rtol = 1e-8
+        # but a tighter (normal) confidence interval than the bare vector's t
+        wid(f) = [hi - lo for (lo, hi) in confint(f; level = 0.95)]
+        @test all(wid(fit_var) .< wid(fit_known))
+    end
+
+    @testset "PrecisionMatrix matches a bare matrix with a normal CI" begin
+        M = LinearAlgebra.diagm(wt)                         # diagonal precision matrix
+        fit_mat = curve_fit(model, x, y, M, p0)            # bare matrix
+        fit_pm = curve_fit(model, x, y, PrecisionMatrix(M), p0)
+        # a diagonal precision matrix equals the bare-vector / PrecisionWeights fit
+        @test coef(fit_pm) ≈ coef(fit_known) rtol = 1e-8
+        @test vcov(fit_pm) ≈ vcov(fit_known) rtol = 1e-8
+        @test vcov(fit_pm) ≈ vcov(fit_mat) rtol = 1e-8
+        # PrecisionMatrix uses the normal CI, the bare matrix keeps Student-t
+        wid(f) = [hi - lo for (lo, hi) in confint(f; level = 0.95)]
+        @test all(wid(fit_pm) .< wid(fit_mat))
+    end
+
     @testset "FrequencyWeights count observations" begin
         counts = [3, 1, 1, 2, 1]
         fit_freq = curve_fit(model, x, y, FrequencyWeights(counts), p0)


### PR DESCRIPTION
Use typed weights to reconcile various interpretations. For now, we will allow the old version. It does have an inconsistency in the use of dof for the ci calculations becuase if we assume a known sigma there is no need to use a small sample critical value. In a breaking release the vector/matrix input will be deprecated an only the typed versions will be used. I'll open an issue for that.