### PR TITLE
Remove deprecations and release v1.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LsqFit"
 uuid = "2fda8390-95c7-5789-9bda-21331edee243"
-version = "0.16.1"
+version = "1.0.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Existing Functionality
 * `jacobian`: (optional) function that returns the Jacobian matrix of `model`
 * `x`: the independent variable
 * `y`: the dependent variable that constrains `model`
-* `w`: (optional) weight applied to the residual; use `PrecisionWeights(1 ./ σ.^2)` (or `PrecisionMatrix(inv(Σ))` for correlated errors) when the variances are known, or `AnalyticWeights`/`FrequencyWeights` to estimate the scale. Passing a bare vector or matrix still works but is deprecated.
+* `w`: (optional) weight applied to the residual; use `PrecisionWeights(1 ./ σ.^2)` (or `PrecisionMatrix(inv(Σ))` for correlated errors) when the variances are known, or `AnalyticWeights`/`FrequencyWeights` to estimate the scale. Passing a bare vector or matrix is no longer accepted (removed in 1.0).
 * `p0`: initial guess of the model parameters
 * `kwargs`: tuning parameters for fitting, passed to `levenberg_marquardt`, such as `maxIter`, `show_trace` or `lower` and `upper` bounds
 * `fit`: composite type of results (`LsqFitResult`)

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -331,9 +331,10 @@ fit = curve_fit(m, tdata, ydata, wt, p0)
 cov = vcov(fit)
 ```
 
-!!! warning "Deprecated"
-    Passing a bare `1 ./ var(ε)` vector or `inv(cov_ε)` matrix still works but is
-    deprecated; use `PrecisionWeights` / `PrecisionMatrix` instead.
+!!! warning "Removed"
+    Passing a bare `1 ./ var(ε)` vector or `inv(cov_ε)` matrix throws an
+    `ArgumentError` (deprecated in 0.16, removed in 1.0); use `PrecisionWeights` /
+    `PrecisionMatrix` instead.
 
 If the variances are known only up to a common factor,
 ``ε \sim N(0, σ^2 W^{-1})`` with unknown ``σ^2``, the covariance is

--- a/docs/src/weights.md
+++ b/docs/src/weights.md
@@ -79,12 +79,11 @@ inverse variances in every case.
 | `AnalyticWeights(1 ./ σ.^2)` | estimated | `σ̂² (JᵀWJ)⁻¹` | `n` |
 | `FrequencyWeights(counts)` | estimated | `σ̂² (JᵀWJ)⁻¹` | `∑w` |
 
-!!! warning "Deprecated: bare vector and matrix weights"
-    Passing a bare `1 ./ σ.^2` vector or `inv(Σ)` matrix is deprecated and emits a
-    warning. Wrap them in [`PrecisionWeights`](@ref) / [`PrecisionMatrix`](@ref)
-    for the same known-variance covariance (with the calibrated normal interval),
-    or in `AnalyticWeights` to estimate the scale. The bare forms previously kept a
-    Student-t interval purely for backwards compatibility.
+!!! warning "Removed: bare vector and matrix weights"
+    Passing a bare `1 ./ σ.^2` vector or `inv(Σ)` matrix throws an `ArgumentError`
+    (deprecated in 0.16, removed in 1.0). Wrap them in [`PrecisionWeights`](@ref) /
+    [`PrecisionMatrix`](@ref) for the known-variance covariance (with the calibrated
+    normal interval), or in `AnalyticWeights` to estimate the scale.
 
 `AnalyticWeights`, `FrequencyWeights` are re-exported from
 [StatsBase](https://juliastats.org/StatsBase.jl/stable/weights/) and keep their
@@ -93,17 +92,17 @@ StatsBase meaning; `PrecisionWeights` and `PrecisionMatrix` are defined by LsqFi
 * `PrecisionWeights` are the exact, known inverse variances (independent errors)
   and `PrecisionMatrix` the exact, known precision matrix `inv(Σ)` (correlated
   errors). The scale is known, so `vcov` has no MSE factor and the confidence
-  interval uses the normal critical value. They are the typed forms of a bare
-  vector and a bare matrix.
+  interval uses the normal critical value. They are the required forms for
+  known-variance weighting (a bare vector/matrix is no longer accepted).
 * `AnalyticWeights` are reliability or inverse-variance weights. They give a
   relative importance, so the common scale is estimated and the result does not
   depend on the overall magnitude of the weights. This is the convention used by
   MATLAB `nlinfit`, Origin and LabPlot.
 * `FrequencyWeights` are integer counts: `wᵢ` means observation `i` was seen `wᵢ`
   times, so `nobs = ∑w`.
-* A bare vector or matrix (deprecated) is taken as the exact inverse (co)variance,
-  like `PrecisionWeights`/`PrecisionMatrix`, but keeps the Student-t interval for
-  backwards compatibility. Prefer the typed forms.
+A bare vector or matrix is no longer accepted: it was the exact inverse
+(co)variance with a Student-t interval, kept for backwards compatibility, and is
+now an error. Use `PrecisionWeights`/`PrecisionMatrix` instead.
 
 StatsBase has no weight type for the known-variance case (all of its corrected
 weights estimate the scale), which is why `PrecisionWeights`/`PrecisionMatrix`
@@ -222,14 +221,12 @@ is the case that is actually wrong.
 `margin_error` and `confint` use Student-t for the unweighted case. Typed weights
 use Student-t when the scale is estimated (`AnalyticWeights`, `FrequencyWeights`)
 and the normal quantile when it is known (`PrecisionWeights`, `PrecisionMatrix`).
-A deprecated bare vector or matrix has the same covariance as `PrecisionWeights` /
-`PrecisionMatrix` but keeps the Student-t reference for backwards compatibility.
 
 ## Choosing weights
 
 * Known `σᵢ`, trusted as absolute: `PrecisionWeights(1 ./ σ.^2)`, or
-  `PrecisionMatrix(inv(Σ))` for correlated errors. (Passing a bare `1 ./ σ.^2`
-  vector or `inv(Σ)` matrix is deprecated.)
+  `PrecisionMatrix(inv(Σ))` for correlated errors. (A bare `1 ./ σ.^2` vector or
+  `inv(Σ)` matrix is no longer accepted.)
 * Only relative precisions known, or results that match MATLAB/Origin/LabPlot:
   `AnalyticWeights(1 ./ σ.^2)`.
 * Repeated or aggregated counts: `FrequencyWeights(counts)`.

--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -52,34 +52,6 @@ function check_data_health(xdata, ydata, wt = [])
 
 end
 
-# Convert legacy symbol-based autodiff to AbstractADType for NLSolversBase v8 compatibility.
-# Symbols were accepted in v7 but are no longer valid in v8.
-function _autodiff_adtype(autodiff::AbstractADType)
-    autodiff
-end
-function _autodiff_adtype(autodiff::Symbol)
-    Base.depwarn(
-        "Passing `autodiff` as a Symbol (e.g. `$(repr(autodiff))`) is deprecated. " *
-        "Use an `ADTypes` backend such as `AutoForwardDiff()` or `AutoFiniteDiff(fdjtype = Val(:central))` instead.",
-        :curve_fit,
-    )
-    if autodiff in (:finite, :central)
-        return AutoFiniteDiff(fdjtype = Val(:central))
-    elseif autodiff == :finiteforward
-        return AutoFiniteDiff(fdjtype = Val(:forward))
-    elseif autodiff == :finitecomplex
-        return AutoFiniteDiff(fdjtype = Val(:complex))
-    elseif autodiff in (:forward, :forwarddiff)
-        return AutoForwardDiff()
-    else
-        throw(
-            ArgumentError(
-                "Unsupported autodiff symbol: $(repr(autodiff)). Use `AutoFiniteDiff()` or `AutoForwardDiff()`.",
-            ),
-        )
-    end
-end
-
 # provide a method for those who have their own Jacobian function
 function lmfit(f, g, p0::AbstractArray, wt::AbstractArray; kwargs...)
     r = f(p0)
@@ -108,7 +80,7 @@ function lmfit(
         p0,
         copy(r);
         inplace = true,
-        autodiff = _autodiff_adtype(autodiff),
+        autodiff = autodiff,
     )
     lmfit(R, p0, wt; kwargs...)
 end
@@ -141,7 +113,7 @@ function lmfit(
         p0,
         copy(r);
         inplace = false,
-        autodiff = _autodiff_adtype(autodiff),
+        autodiff = autodiff,
     )
     lmfit(R, p0, wt; kwargs...)
 end
@@ -218,11 +190,12 @@ confidence intervals. `vcov(fit)` is the parameter covariance and `stderror(fit)
 its square-rooted diagonal. The "Weights" page of the manual has the derivation
 and a coverage check.
 
-!!! warning "Deprecated"
-    Passing a bare inverse-variance `Vector` or inverse-covariance `Matrix` is
-    deprecated. Use `PrecisionWeights(1 ./ σ.^2)` / `PrecisionMatrix(inv(Σ))` for
-    the same known-variance covariance (with a calibrated normal interval), or
-    `AnalyticWeights` to estimate the scale.
+!!! note
+    `wt` must be one of the weight types above. Passing a bare inverse-variance
+    `Vector` or inverse-covariance `Matrix` is an error (deprecated in 0.16,
+    removed in 1.0); wrap it in `PrecisionWeights(1 ./ σ.^2)` /
+    `PrecisionMatrix(inv(Σ))` for a known variance, or `AnalyticWeights` to
+    estimate the scale.
 
 ## Example
 ```julia
@@ -298,7 +271,7 @@ function curve_fit(
     kwargs...,
 )
     check_data_health(xdata, ydata, wt)
-    _maybe_depwarn_bare_weights(wt)
+    _assert_typed_weights(wt)
     # construct a weighted cost function, with a vector weight for each ydata
     # for example, this might be wt = 1/sigma where sigma is some error term
     u = sqrt.(wt) # to be consistant with the matrix form
@@ -323,7 +296,7 @@ function curve_fit(
     kwargs...,
 )
     check_data_health(xdata, ydata, wt)
-    _maybe_depwarn_bare_weights(wt)
+    _assert_typed_weights(wt)
     u = sqrt.(wt) # to be consistant with the matrix form
 
     if inplace
@@ -346,7 +319,7 @@ function curve_fit(
     kwargs...,
 )
     check_data_health(xdata, ydata, wt)
-    _maybe_depwarn_bare_weights(wt)
+    _assert_typed_weights(wt)
 
     # as before, construct a weighted cost function with where this
     # method uses a matrix weight.
@@ -371,7 +344,7 @@ function curve_fit(
     kwargs...,
 )
     check_data_health(xdata, ydata, wt)
-    _maybe_depwarn_bare_weights(wt)
+    _assert_typed_weights(wt)
 
     u = cholesky(wt).U
 
@@ -418,21 +391,15 @@ end
 Base.size(pm::PrecisionMatrix) = size(pm.values)
 Base.getindex(pm::PrecisionMatrix, i::Int, j::Int) = pm.values[i, j]
 
-# Bare (untyped) vector/matrix weights are deprecated in favour of the typed
-# weight forms, which make the variance assumption explicit and use the matching
-# confidence interval. The typed weights subtype `AbstractVector`/`AbstractMatrix`,
-# so they reach the same `curve_fit` methods; these dispatches keep them silent
-# and warn only for a plain vector or matrix.
-_maybe_depwarn_bare_weights(::AbstractWeights) = nothing
-_maybe_depwarn_bare_weights(::PrecisionMatrix) = nothing
-function _maybe_depwarn_bare_weights(::AbstractVector)
-    Base.depwarn("Passing weights as a bare `Vector` is deprecated. Wrap the inverse variances `1 ./ σ.^2` in `PrecisionWeights` to keep the known-variance covariance (now with the calibrated normal confidence interval instead of Student-t), or in `AnalyticWeights` to estimate the scale.", :curve_fit)
-    return nothing
-end
-function _maybe_depwarn_bare_weights(::AbstractMatrix)
-    Base.depwarn("Passing weights as a bare `Matrix` is deprecated. Wrap the inverse covariance `inv(Σ)` in `PrecisionMatrix` instead (this also switches the confidence interval from Student-t to the calibrated normal quantile).", :curve_fit)
-    return nothing
-end
+# Weights must carry their statistical meaning in their type: PrecisionWeights /
+# PrecisionMatrix for a known variance, AnalyticWeights / FrequencyWeights for an
+# estimated scale. The typed weights subtype `AbstractVector`/`AbstractMatrix`, so
+# they reach the same `curve_fit` methods; these dispatches pass them through and
+# reject a plain vector or matrix (which was deprecated in 0.16 and removed in 1.0).
+_assert_typed_weights(::AbstractWeights) = nothing
+_assert_typed_weights(::PrecisionMatrix) = nothing
+_assert_typed_weights(::AbstractVector) = throw(ArgumentError("Bare `Vector` weights are no longer supported. Wrap the inverse variances `1 ./ σ.^2` in `PrecisionWeights` (known variance) or `AnalyticWeights` (estimated scale)."))
+_assert_typed_weights(::AbstractMatrix) = throw(ArgumentError("Bare `Matrix` weights are no longer supported. Wrap the inverse covariance `inv(Σ)` in `PrecisionMatrix`."))
 
 # Whether the residual scale σ² is estimated from the fit and multiplied into the
 # covariance, or assumed known because the weights are the exact inverse
@@ -525,19 +492,3 @@ function StatsAPI.confint(fit::LsqFitResult; level = 0.95, rtol::Real = NaN, ato
     margin_of_errors = margin_error(fit, 1 - level; rtol = rtol, atol = atol)
     return collect(zip(coef(fit) - margin_of_errors, coef(fit) + margin_of_errors))
 end
-
-@deprecate(
-    confidence_interval(fit::LsqFitResult, alpha = 0.05; rtol::Real = NaN, atol::Real = 0),
-    confint(fit; level = (1 - alpha), rtol = rtol, atol = atol)
-)
-
-@deprecate estimate_covar(fit::LsqFitResult) vcov(fit)
-
-@deprecate standard_errors(args...; kwargs...) stderror(args...; kwargs...)
-
-@deprecate estimate_errors(
-    fit::LsqFitResult,
-    confidence = 0.95;
-    rtol::Real = NaN,
-    atol::Real = 0,
-) margin_error(fit, 1 - confidence; rtol = rtol, atol = atol)

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -166,26 +166,11 @@ end
         @test norm(fit.param - [1.0, 2.0]) < 0.05
     end
 
-    # legacy symbols: _autodiff_adtype emits a deprecation warning and maps correctly
-    @test_logs (:warn, r"deprecated") LsqFit._autodiff_adtype(:finite)
-    @test LsqFit._autodiff_adtype(:finite) == AutoFiniteDiff(fdjtype = Val(:central))
-    @test LsqFit._autodiff_adtype(:central) == AutoFiniteDiff(fdjtype = Val(:central))
-    @test LsqFit._autodiff_adtype(:finiteforward) ==
-          AutoFiniteDiff(fdjtype = Val(:forward))
-    @test LsqFit._autodiff_adtype(:finitecomplex) ==
-          AutoFiniteDiff(fdjtype = Val(:complex))
-    @test LsqFit._autodiff_adtype(:forward) == AutoForwardDiff()
-    @test LsqFit._autodiff_adtype(:forwarddiff) == AutoForwardDiff()
-
-    # legacy symbols still produce a correct fit end-to-end
-    for sym in (:finite, :central, :finiteforward, :finitecomplex, :forward, :forwarddiff)
-        fit = curve_fit(model, xdata, ydata, p0; autodiff = sym)
-        @test fit.converged
-        @test norm(fit.param - [1.0, 2.0]) < 0.1
+    # Symbol-based autodiff was removed in 1.0; only ADTypes backends are accepted.
+    @test !isdefined(LsqFit, :_autodiff_adtype)
+    for sym in (:finite, :central, :forward, :forwarddiff)
+        @test_throws Exception curve_fit(model, xdata, ydata, p0; autodiff = sym)
     end
-
-    # invalid symbol throws ArgumentError
-    @test_throws ArgumentError LsqFit._autodiff_adtype(:bad_symbol)
 
     # concretely-typed model with AutoForwardDiff gives a friendly, actionable error
     model_typed(x::AbstractVector{Float64}, p::AbstractVector{Float64}) =

--- a/test/curve_fit.jl
+++ b/test/curve_fit.jl
@@ -5,6 +5,14 @@ using LsqFit, Test, StableRNGs, LinearAlgebra
     @test_throws ErrorException(
         "The independent variable (`x`) contains `missing` values and a fit cannot be performed",
     ) LsqFit.check_data_health(tdata, tdata)
+    # missing in `y` and in the weights are rejected too
+    cleandata = collect(1:6)
+    @test_throws ErrorException(
+        "The dependent variable (`y`) contains `missing` values and a fit cannot be performed",
+    ) LsqFit.check_data_health(cleandata, tdata)
+    @test_throws ErrorException(
+        "Weight data contains `missing` values and a fit cannot be performed",
+    ) LsqFit.check_data_health(cleandata, cleandata, tdata)
     tdata = [rand(1:10, 5)..., Inf]
     @test_throws ErrorException(
         "The independent variable (`x`) contains non-finite (e.g. `Inf`, `NaN`) values and a fit cannot be performed",
@@ -185,6 +193,17 @@ end
     @test occursin("AutoForwardDiff", err.msg)
     @test occursin("AutoFiniteDiff", err.msg)
     @test occursin("AbstractVector{<:Real}", err.msg)
+end
+
+@testset "non-Dual errors from the optimizer are rethrown" begin
+    # A user-supplied Jacobian that throws something other than a Dual-related
+    # MethodError must propagate unchanged (not be reinterpreted as an autodiff
+    # incompatibility).
+    model(x, p) = p[1] .* exp.(-x .* p[2])
+    x = collect(range(0, 10, length = 20))
+    y = model(x, [1.0, 2.0])
+    badjac(x, p) = throw(ArgumentError("boom in jacobian"))
+    @test_throws ArgumentError("boom in jacobian") curve_fit(model, badjac, x, y, [0.5, 0.5])
 end
 
 @testset "#167" begin

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -45,15 +45,26 @@ using LsqFit, Test, LinearAlgebra, StableRNGs
         @test stderror(fit_known) ≈ sqrt.(diag(vcov(fit_known)))
     end
 
+    # Analytic Jacobian of model(x, p) = p[1] * exp(p[2] * x).
+    jac(x, p) = hcat(exp.(p[2] .* x), p[1] .* x .* exp.(p[2] .* x))
+
     @testset "bare vector/matrix weights are rejected" begin
         # Bare weights were removed in 1.0; they must be wrapped in a weight type.
         # Cover all four weighted methods: vector/matrix × with/without a Jacobian.
-        jac(x, p) = hcat(exp.(p[2] .* x), p[1] .* x .* exp.(p[2] .* x))
         W = LinearAlgebra.diagm(wt)
         @test_throws ArgumentError curve_fit(model, x, y, wt, p0)
         @test_throws ArgumentError curve_fit(model, x, y, W, p0)
         @test_throws ArgumentError curve_fit(model, jac, x, y, wt, p0)
         @test_throws ArgumentError curve_fit(model, jac, x, y, W, p0)
+    end
+
+    @testset "matrix weight with a Jacobian model" begin
+        # A diagonal PrecisionMatrix with a supplied Jacobian must agree with the
+        # vector PrecisionWeights fit (exercises the GLS + Jacobian code path).
+        W = PrecisionMatrix(LinearAlgebra.diagm(wt))
+        fit_mat_jac = curve_fit(model, jac, x, y, W, p0)
+        @test coef(fit_mat_jac) ≈ coef(fit_known) rtol = 1e-8
+        @test vcov(fit_mat_jac) ≈ vcov(fit_known) rtol = 1e-8
     end
 
     @testset "FrequencyWeights count observations" begin

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -47,8 +47,13 @@ using LsqFit, Test, LinearAlgebra, StableRNGs
 
     @testset "bare vector/matrix weights are rejected" begin
         # Bare weights were removed in 1.0; they must be wrapped in a weight type.
+        # Cover all four weighted methods: vector/matrix × with/without a Jacobian.
+        jac(x, p) = hcat(exp.(p[2] .* x), p[1] .* x .* exp.(p[2] .* x))
+        W = LinearAlgebra.diagm(wt)
         @test_throws ArgumentError curve_fit(model, x, y, wt, p0)
-        @test_throws ArgumentError curve_fit(model, x, y, LinearAlgebra.diagm(wt), p0)
+        @test_throws ArgumentError curve_fit(model, x, y, W, p0)
+        @test_throws ArgumentError curve_fit(model, jac, x, y, wt, p0)
+        @test_throws ArgumentError curve_fit(model, jac, x, y, W, p0)
     end
 
     @testset "FrequencyWeights count observations" begin

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -45,38 +45,10 @@ using LsqFit, Test, LinearAlgebra, StableRNGs
         @test stderror(fit_known) ≈ sqrt.(diag(vcov(fit_known)))
     end
 
-    @testset "bare vector/matrix weights are deprecated" begin
-        wid(f) = [hi - lo for (lo, hi) in confint(f; level = 0.95)]
-
-        # A bare vector warns and falls back to the known-variance covariance with
-        # a Student-t interval; PrecisionWeights gives the same covariance but the
-        # calibrated (tighter) normal interval.
-        fit_bare = @test_logs (:warn, r"deprecated") match_mode = :any curve_fit(
-            model,
-            x,
-            y,
-            wt,
-            p0,
-        )
-        @test coef(fit_bare) ≈ coef(fit_known) rtol = 1e-8
-        @test vcov(fit_bare) ≈ vcov(fit_known) rtol = 1e-8
-        @test stderror(fit_bare) ≈ stderror(fit_known) rtol = 1e-8
-        @test all(wid(fit_known) .< wid(fit_bare))   # PrecisionWeights normal < bare t
-
-        # Same story for a bare matrix vs PrecisionMatrix.
-        M = LinearAlgebra.diagm(wt)                         # diagonal precision matrix
-        fit_bare_mat = @test_logs (:warn, r"deprecated") match_mode = :any curve_fit(
-            model,
-            x,
-            y,
-            M,
-            p0,
-        )
-        fit_pm = curve_fit(model, x, y, PrecisionMatrix(M), p0)
-        @test coef(fit_pm) ≈ coef(fit_known) rtol = 1e-8
-        @test vcov(fit_pm) ≈ vcov(fit_known) rtol = 1e-8
-        @test vcov(fit_pm) ≈ vcov(fit_bare_mat) rtol = 1e-8
-        @test all(wid(fit_pm) .< wid(fit_bare_mat))
+    @testset "bare vector/matrix weights are rejected" begin
+        # Bare weights were removed in 1.0; they must be wrapped in a weight type.
+        @test_throws ArgumentError curve_fit(model, x, y, wt, p0)
+        @test_throws ArgumentError curve_fit(model, x, y, LinearAlgebra.diagm(wt), p0)
     end
 
     @testset "FrequencyWeights count observations" begin


### PR DESCRIPTION
Removes everything that was deprecated in the 0.16 line and bumps the version to **1.0.0**.

## Breaking changes

| Removed | Replacement |
|---------|-------------|
| Symbol `autodiff` (`autodiff = :forward`, `:central`, …) | `AutoForwardDiff()` / `AutoFiniteDiff(...)` (ADTypes backends) |
| Bare `Vector` weights `1 ./ σ.^2` | `PrecisionWeights(1 ./ σ.^2)` (known var) or `AnalyticWeights(...)` (estimated scale) |
| Bare `Matrix` weights `inv(Σ)` | `PrecisionMatrix(inv(Σ))` |
| `confidence_interval` | `confint` |
| `estimate_covar` | `vcov` |
| `standard_errors` | `stderror` |
| `estimate_errors` | `margin_error` |

- The `_autodiff_adtype` Symbol→ADType conversion is gone; passing a Symbol now errors.
- Bare vector/matrix weights now throw an `ArgumentError` pointing to the typed weight forms (they previously only warned).
- The four `@deprecate` aliases are deleted (they were not exported).

## Other

- `Project.toml`: `0.16.1` → `1.0.0`.
- Tests updated: the old deprecation-warning tests are now hard-error assertions.
- Docs (`weights.md`, `tutorial.md`, the `curve_fit` docstring, `README.md`) updated from "deprecated" to "removed in 1.0".

`Pkg.test()` passes with no deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)